### PR TITLE
Add DoomArena adapter factory with real fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,15 @@ run:
 	. .venv/bin/activate && python scripts/run_batch.py --exp $(EXP) --seeds "$(SEED)" --trials $(TRIALS) --mode $(MODE) --outdir "$(RUN_DIR)"
 	printf "%s\n" "$(RUN_ID)" > $(RUN_CURRENT)
 
+.ONESHELL: xrun
 xrun:
-	. .venv/bin/activate && python scripts/run_experiment.py --config $(CONFIG) --seed $(SEED) --outdir "$(RUN_DIR)"
+	if [ -x "$(PY)" ]; then PYTHON_BIN="$(PY)"; else PYTHON_BIN="python"; fi; \
+	CMD="$$PYTHON_BIN scripts/run_experiment.py --config $(CONFIG) --seed $(SEED) --outdir \"$(RUN_DIR)\""; \
+	if [ -n "$(MODE_OVERRIDE)" ]; then CMD="$$CMD --mode $(MODE_OVERRIDE)"; fi; \
+	if [ -n "$(TRIALS_OVERRIDE)" ]; then CMD="$$CMD --trials $(TRIALS_OVERRIDE)"; fi; \
+	if [ -n "$(EXP_OVERRIDE)" ]; then CMD="$$CMD --exp $(EXP_OVERRIDE)"; fi; \
+	echo "xrun: $$CMD"; \
+	eval $$CMD; rc=$$?; if [ $$rc -ne 0 ]; then exit $$rc; fi; \
 	printf "%s\n" "$(RUN_ID)" > $(RUN_CURRENT)
 
 sweep:

--- a/README.md
+++ b/README.md
@@ -52,16 +52,24 @@ RUN_ID=$(make latest)
 ls results/$RUN_ID
 ```
 
-### Swapping to real DoomArena classes
+### Running with real DoomArena (optional)
 
-This repo currently uses thin adapters to mirror DoomArena concepts:
+Runs default to the SHIM adapters. When the `doomarena` package is installed locally the runner automatically switches to the real DoomArena / τ-Bench classes whenever `MODE=REAL` is requested; otherwise it prints a warning and falls back to the shim adapters so CI and local demos continue to work.
 
-| Lab adapter | DoomArena concept (target) |
-| --- | --- |
-| `adapters.attacks.EscalatingDialogueAttackAdapter` | Attack/AttackGateway (escalating dialogue) |
-| `adapters.filters.OutOfPolicyRefundFilter` | Success predicate / policy filter |
+1. Install the real adapters (if you have access):
 
-**Next step:** replace these adapters with the real DoomArena/τ-Bench classes and keep the same CLI + JSONL outputs so experiment configs remain unchanged.
+   ```bash
+   pip install doomarena
+   ```
+
+2. Launch a run in REAL mode (falls back to SHIM if imports fail):
+
+   ```bash
+   make real1
+   make xsweep MODE=REAL CONFIG=configs/airline_escalating_v1/exp.yaml
+   ```
+
+   You can also set `DOOMARENA_MODE=REAL` in the environment instead of passing `MODE` on the CLI.
 
 ## Results
 
@@ -77,7 +85,7 @@ with more trials carry proportionally more weight in the chart.
 
 ![Results summary](results/summary.svg)
 
-# Experiment summary — 2025-09-16T19:31:21+00:00
+# Experiment summary — 2025-09-18T10:53:03+00:00
 
 - Experiments: 2
 - Total trials: 12
@@ -114,9 +122,9 @@ Use `make check-schema` to verify the file matches the expected schema.
 
 |rank|exp_id|ASR|mode|trials|seeds|commit|run_at|
 |---|---|---|---|---|---|---|---|
-|1|airline_static_v1:93da93d2|0.333|SHIM|3|12,11|6048d3b|2025-09-16T19:31:19.911401+00:00|
-|2|airline_static_v1:93da93d2|0.333|SHIM|3|11,12|6048d3b|2025-09-16T19:31:19.676163+00:00|
-|3|airline_escalating_v1:3762657d|0.333|SHIM|3|12|6048d3b|2025-09-16T19:31:19.265401+00:00|
-|4|airline_escalating_v1:3762657d|0.333|SHIM|3|11|6048d3b|2025-09-16T19:31:19.016015+00:00|
+|1|airline_static_v1:93da93d2|0.333|SHIM|3|12,11|21fd63e|2025-09-18T10:53:01.330519+00:00|
+|2|airline_static_v1:93da93d2|0.333|SHIM|3|11,12|21fd63e|2025-09-18T10:53:01.153808+00:00|
+|3|airline_escalating_v1:3762657d|0.333|SHIM|3|12|21fd63e|2025-09-18T10:53:00.634317+00:00|
+|4|airline_escalating_v1:3762657d|0.333|SHIM|3|11|21fd63e|2025-09-18T10:53:00.453650+00:00|
 <!-- TOPN:END -->
 

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapter helpers for DoomArena shim and real integrations."""
+
+from .factory import AdapterComponents, get_components
+
+__all__ = ["AdapterComponents", "get_components"]

--- a/adapters/factory.py
+++ b/adapters/factory.py
@@ -1,0 +1,147 @@
+"""Factory helpers for DoomArena adapter components."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, Optional
+
+REAL_AVAILABLE = False
+
+try:  # pragma: no cover - optional dependency
+    from doomarena.attacks import EscalatingDialogueAttack as _RealEscalatingAttack
+    from doomarena.filters import OutOfPolicyRefundFilter as _RealRefundFilter
+except Exception:  # pragma: no cover - optional dependency
+    _RealEscalatingAttack = None
+    _RealRefundFilter = None
+else:  # pragma: no cover - optional dependency
+    REAL_AVAILABLE = True
+
+
+@dataclass
+class AdapterComponents:
+    """Container for DoomArena adapter component constructors."""
+
+    attack: Callable[..., Any]
+    policy_filter: Callable[..., Any]
+    mode: str
+
+
+def _coerce_levels(levels: Optional[Iterable[Any]]) -> list[str]:
+    if not levels:
+        return []
+    return [str(item) for item in levels]
+
+
+def _make_shim_attack_factory(exp: str | None) -> Callable[..., Any]:
+    from .attacks import EscalatingDialogueAttackAdapter
+
+    def factory(**kwargs: Any) -> Any:
+        levels = _coerce_levels(kwargs.get("levels"))
+        return EscalatingDialogueAttackAdapter(levels=levels)
+
+    return factory
+
+
+def _make_shim_filter_factory(exp: str | None) -> Callable[..., Any]:
+    from .filters import OutOfPolicyRefundFilter
+
+    def factory(**kwargs: Any) -> Any:
+        threshold = int(kwargs.get("threshold", 200))
+        return OutOfPolicyRefundFilter(threshold=threshold)
+
+    return factory
+
+
+def _make_real_attack_factory(exp: str | None) -> Callable[..., Any]:  # pragma: no cover - optional dependency
+    def factory(**kwargs: Any) -> Any:
+        levels = _coerce_levels(kwargs.get("levels"))
+        config: Dict[str, Any] = dict(kwargs.get("config") or {})
+
+        attack_kwargs: Dict[str, Any] = {}
+        if levels:
+            attack_kwargs["levels"] = levels
+        if config:
+            attack_kwargs["config"] = config
+        if exp:
+            attack_kwargs.setdefault("exp", exp)
+
+        attack = _RealEscalatingAttack(**attack_kwargs)  # type: ignore[misc]
+
+        reset = getattr(attack, "reset", None)
+        apply = getattr(attack, "apply", None)
+
+        if callable(reset) and callable(apply):
+            return attack
+
+        class _AttackWrapper:
+            def __init__(self, inner: Any) -> None:
+                self._inner = inner
+                self._reset = getattr(inner, "reset", None)
+                self._call = getattr(inner, "apply", None) or getattr(inner, "__call__", None)
+
+            def reset(self) -> None:
+                if callable(self._reset):
+                    self._reset()
+
+            def apply(self, user_msg: str) -> str:
+                if callable(self._call):
+                    return self._call(user_msg)
+                raise AttributeError("Attack object does not support apply()")
+
+        return _AttackWrapper(attack)
+
+    return factory
+
+
+def _make_real_filter_factory(exp: str | None) -> Callable[..., Any]:  # pragma: no cover - optional dependency
+    def factory(**kwargs: Any) -> Any:
+        threshold = int(kwargs.get("threshold", 200))
+        config: Dict[str, Any] = dict(kwargs.get("config") or {})
+
+        filter_kwargs: Dict[str, Any] = {"threshold": threshold}
+        if config:
+            filter_kwargs["config"] = config
+        if exp:
+            filter_kwargs.setdefault("exp", exp)
+
+        filter_obj = _RealRefundFilter(**filter_kwargs)  # type: ignore[misc]
+
+        if callable(filter_obj):
+            return filter_obj
+
+        class _FilterWrapper:
+            def __init__(self, inner: Any) -> None:
+                self._inner = inner
+
+            def __call__(self, *args: Any, **kw: Any) -> Any:
+                call_method = getattr(self._inner, "__call__", None)
+                if callable(call_method):
+                    return call_method(*args, **kw)
+                raise AttributeError("Filter object is not callable")
+
+        return _FilterWrapper(filter_obj)
+
+    return factory
+
+
+def get_components(mode: str, exp: str | None = None) -> AdapterComponents:
+    """Return constructor callables for the requested adapter mode."""
+
+    requested = (mode or "SHIM").strip().upper()
+    use_real = requested == "REAL" and REAL_AVAILABLE
+
+    if requested == "REAL" and not REAL_AVAILABLE:
+        print("[warn] REAL mode requested but DoomArena not available; falling back to SHIM.")
+
+    if use_real:
+        print("[info] Using REAL DoomArena adapters.")
+        return AdapterComponents(
+            attack=_make_real_attack_factory(exp),
+            policy_filter=_make_real_filter_factory(exp),
+            mode="REAL",
+        )
+
+    return AdapterComponents(
+        attack=_make_shim_attack_factory(exp),
+        policy_filter=_make_shim_filter_factory(exp),
+        mode="SHIM",
+    )


### PR DESCRIPTION
## Summary
- add an adapter factory that selects REAL DoomArena classes when available and otherwise falls back to the existing shim
- update the experiment runner to source attack/filter constructors from the factory, honor the DOOMARENA_MODE env var, and log REAL fallback/activation
- thread MODE through the `xrun` target and document optional REAL usage in the README while exporting the factory helpers

## Testing
- `make demo`
- `python scripts/run_experiment.py --config configs/airline_escalating_v1/exp.yaml --seed 41 --mode REAL --outdir results/test_real`
- `pytest -q` *(fails: `make report` invoked by the test expects populated RUN_ID output directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe221fe948329b3847fe379a72366