### PR TITLE
chore(make): normalize test artifacts into RUN_DIR before pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,19 @@ test: install demo
 	@test -f results/summary.svg || (echo "missing results/summary.svg" && exit 1)
 	@find results -type f -name '*seed*.jsonl' -print -quit | grep -q . || (echo "no per-seed jsonl files found under results/" && exit 1)
 	@echo "✅ Results schema & artifacts look good."
-	@if [ -x "$(PY)" ]; then \
-	"$(PY)" -m pytest -q; \
+	@RUN_ID="test_$$(date +%s)"; \
+	RUN_DIR="results/$${RUN_ID}"; \
+	mkdir -p "$$RUN_DIR"; \
+	cp -f results/summary.csv "$$RUN_DIR/" 2>/dev/null || true; \
+	cp -f results/summary.svg "$$RUN_DIR/" 2>/dev/null || true; \
+	find results -maxdepth 3 -type f -name '*seed*.jsonl' -exec cp -f {} "$$RUN_DIR/" \; 2>/dev/null || true; \
+	cp -f results/summary.md "$$RUN_DIR/" 2>/dev/null || true; \
+	printf "%s\n" "$$RUN_ID" > results/.run_id; \
+	echo "🧪 Normalized test artifacts into $$RUN_DIR"; \
+	if [ -x "$(PY)" ]; then \
+	  "$(PY)" -m pytest -q; \
 	else \
-	pytest -q; \
+	  pytest -q; \
 	fi
 
 check-schema: venv


### PR DESCRIPTION
## Summary
* normalize quick-run artifacts into results/<RUN_ID>/ prior to pytest so reporting/tests find expected run structure
* ensure summary/csv/svg/jsonl files are copied into the normalized run directory and record the run id for downstream make targets

## Testing
* make demo
* make test

------
https://chatgpt.com/codex/tasks/task_e_68cbe851d6c88329857577636b67c43e