### PR TITLE
Use printf for normalized test artifact message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test: install demo
 	find results -maxdepth 3 -type f -name '*seed*.jsonl' -exec cp -f {} "$$RUN_DIR/" \; 2>/dev/null || true; \
 	cp -f results/summary.md "$$RUN_DIR/" 2>/dev/null || true; \
 	printf "%s\n" "$$RUN_ID" > results/.run_id; \
-	echo "🧪 Normalized test artifacts into $$RUN_DIR"; \
+	printf '🧪 Normalized test artifacts into %s\n' "$$RUN_DIR"; \
 	if [ -x "$(PY)" ]; then \
 	  "$(PY)" -m pytest -q; \
 	else \


### PR DESCRIPTION
## Summary
- replace the echo command in the `test` target with `printf` so the normalized artifact message safely handles the run directory value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc0153c33c8329b56c5fbe928e34dd