### PR TITLE
Update README to reference open-artifacts workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _Demo-first companion to ServiceNow/DoomArena. Build tiny, repeatable agent secu
 ## Why this exists
 Teams need **fast iteration** and **CI-friendly artifacts** to reason about agent risks in context. DoomArena-Lab gives you:
 - **Modes**: **SHIM** (simulation adapters) now; **REAL** (upstream DoomArena adapters) when available, with SHIM fallback.
-- **Make UX**: `make demo`, `make xsweep CONFIG=...`, `make report`.
+- **Make UX**: `make demo`, `make xsweep CONFIG=...`, `make report`, `make open-artifacts`.
 - **Artifacts**: Timestamped run dirs under `results/<RUN_DIR>/` with `summary.csv`, `summary.svg`, and (when produced) per-seed JSONL traces.
 - **Metrics/plots**: **Trial-weighted** micro-average ASR in a grouped-bar chart.
 
@@ -17,13 +17,13 @@ make demo
 # 2) Validate/report (asserts CSV/SVG exist)
 make report
 
-# 3) Inspect the most recent artifacts (SVG/CSV)
-ls results/LATEST
+# 3) Open the most recent artifacts (SVG/CSV)
+make open-artifacts
 ```
 
 Use a specific config:
 ```bash
-make xsweep CONFIG=configs/airline_static_v1/run.yaml
+make xsweep CONFIG=configs/airline_static_v1.yaml
 ```
 
 ### Latest Results (auto)
@@ -63,6 +63,8 @@ results/
 - `make demo` — tiny SHIM sweep to produce a minimal `results/<RUN_DIR>/`.
 - `make xsweep CONFIG=...` — run a configurable sweep.
 - `make report` — asserts `summary.csv` & `summary.svg`; updates `results/LATEST`.
+- `make latest` — refreshes `results/LATEST` to the newest run with `summary.csv` & `summary.svg`.
+- `make open-artifacts` — opens `results/LATEST/summary.svg` and `summary.csv`.
 
 ## CI
 The smoke workflow runs a tiny SHIM sweep and publishes artifacts. It also updates `results/LATEST` for quick inspection in PRs.


### PR DESCRIPTION
## Summary
- document `make open-artifacts` in the quick start and Make UX bullets
- correct the xsweep example path and describe the `make latest` target for artifacts

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cc487594008329a1ac04a4e518aa9f