### PR TITLE
Add tooling to verify latest artifacts wiring

### DIFF
--- a/.github/workflows/verify-latest.yml
+++ b/.github/workflows/verify-latest.yml
@@ -1,0 +1,17 @@
+name: verify-latest-wiring
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Run verifier
+        run: python tools/verify_latest_setup.py

--- a/Makefile
+++ b/Makefile
@@ -159,13 +159,12 @@ notes:
 		python scripts/aggregate_results.py --outdir "$(RUN_DIR)"; \
 	fi
 
-report: aggregate plot notes
+report: latest aggregate plot notes
 	mkdir -p results
 	cp -f "$(RUN_DIR)/summary.csv" results/summary.csv
 	cp -f "$(RUN_DIR)/summary.svg" results/summary.svg
 	cp -f "$(RUN_DIR)/summary.md" results/summary.md
 	cp -f "$(RUN_DIR)/notes.md" results/notes.md 2>/dev/null || true
-	printf "%s\n" "$(RUN_ID)" > $(RUN_LATEST)
 	rm -f $(RUN_CURRENT)
 	if [ -x "$(PY)" ]; then \
 		"$(PY)" scripts/update_readme_results.py; \
@@ -194,10 +193,24 @@ ci: install
 	$(MAKE) xsweep MODE=SHIM TRIALS=3 SEEDS=41,42 RUN_ID=$(RUN_ID)
 	$(MAKE) report RUN_ID=$(RUN_ID)
 
-.PHONY: latest
+.PHONY: latest open-artifacts verify-latest-setup
 latest:
-	@if [ -f $(RUN_LATEST) ]; then \
-		cat $(RUN_LATEST); \
+	@if [ -x "$(PY)" ]; then \
+		RUN_ID="$(RUN_ID)" "$(PY)" tools/latest_run.py; \
 	else \
-		echo "No published run."; \
+		RUN_ID="$(RUN_ID)" python tools/latest_run.py; \
+	fi
+
+open-artifacts:
+	@if [ -x "$(PY)" ]; then \
+		RUN_ID="$(RUN_ID)" "$(PY)" tools/open_artifacts.py; \
+	else \
+		RUN_ID="$(RUN_ID)" python tools/open_artifacts.py; \
+	fi
+
+verify-latest-setup:
+	@if [ -x "$(PY)" ]; then \
+		"$(PY)" tools/verify_latest_setup.py; \
+	else \
+		python tools/verify_latest_setup.py; \
 	fi

--- a/tools/latest_run.py
+++ b/tools/latest_run.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Utilities for discovering and updating the results/LATEST symlink."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESULTS_DIR = REPO_ROOT / "results"
+LATEST_LINK = RESULTS_DIR / "LATEST"
+SUMMARY_FILES = ("summary.csv", "summary.svg")
+
+
+@dataclass
+class RunInfo:
+    path: Path
+    mtime: float
+
+    @property
+    def run_id(self) -> str:
+        return self.path.name
+
+
+def _iter_candidate_runs(base: Path) -> Iterable[RunInfo]:
+    if not base.exists():
+        return []
+    runs: list[RunInfo] = []
+    for child in sorted(base.iterdir()):
+        if child.name == "LATEST":
+            continue
+        if not child.is_dir():
+            continue
+        if not all((child / name).exists() for name in SUMMARY_FILES):
+            continue
+        try:
+            mtime = max((child / name).stat().st_mtime for name in SUMMARY_FILES)
+        except FileNotFoundError:
+            continue
+        runs.append(RunInfo(path=child, mtime=mtime))
+    return runs
+
+
+def _select_latest_run(base: Path) -> Optional[RunInfo]:
+    candidates = list(_iter_candidate_runs(base))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda info: info.mtime, reverse=True)
+    return candidates[0]
+
+
+def _desired_run(run_id: Optional[str]) -> Optional[RunInfo]:
+    if run_id:
+        run_dir = RESULTS_DIR / run_id
+        if run_dir.is_dir():
+            mtimes = []
+            for name in SUMMARY_FILES:
+                artifact = run_dir / name
+                try:
+                    mtimes.append(artifact.stat().st_mtime)
+                except FileNotFoundError:
+                    continue
+            try:
+                mtime = max(mtimes)
+            except ValueError:
+                try:
+                    mtime = run_dir.stat().st_mtime
+                except FileNotFoundError:
+                    return None
+            return RunInfo(path=run_dir, mtime=mtime)
+    return _select_latest_run(RESULTS_DIR)
+
+
+def ensure_latest(run_id: Optional[str] = None, *, update: bool = True) -> Optional[RunInfo]:
+    """Return the run used for LATEST and optionally update the symlink."""
+
+    run = _desired_run(run_id)
+    if run is None:
+        return None
+
+    if update:
+        RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        target = run.path
+        try:
+            if LATEST_LINK.is_symlink() or LATEST_LINK.exists():
+                if LATEST_LINK.is_symlink() or LATEST_LINK.is_file():
+                    LATEST_LINK.unlink()
+                elif LATEST_LINK.is_dir():
+                    shutil.rmtree(LATEST_LINK)
+        except FileNotFoundError:
+            pass
+
+        try:
+            LATEST_LINK.symlink_to(target)
+        except OSError:
+            # Fallback for platforms without symlink support: write a pointer file.
+            with LATEST_LINK.open("w", encoding="utf-8") as fh:
+                fh.write(str(target.resolve()))
+    return run
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Update results/LATEST to the newest run.")
+    parser.add_argument("--run-id", help="Specific run ID to mark as latest", default=None)
+    parser.add_argument(
+        "--show-only",
+        action="store_true",
+        help="Only display the resolved run without modifying results/LATEST.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    run_id_env = os.environ.get("RUN_ID")
+    run = ensure_latest(args.run_id or run_id_env, update=not args.show_only)
+
+    if run is None:
+        print("No runs with summary.csv and summary.svg were found under results/", file=sys.stderr)
+        return 0
+
+    rel_path = run.path.relative_to(REPO_ROOT)
+    action = "Resolved" if args.show_only else "Updated"
+    print(f"{action} results/LATEST → {rel_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/open_artifacts.py
+++ b/tools/open_artifacts.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Open key artifacts from the latest DoomArena-Lab run."""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+from latest_run import ensure_latest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_NAMES = ("summary.svg", "summary.csv")
+
+
+def _open_with_default_app(path: Path) -> None:
+    system = platform.system().lower()
+    if system == "darwin":
+        subprocess.run(["open", str(path)], check=False)
+    elif system == "windows":
+        os.startfile(str(path))  # type: ignore[attr-defined]
+    else:
+        subprocess.run(["xdg-open", str(path)], check=False)
+
+
+def main() -> int:
+    run_info = ensure_latest(os.environ.get("RUN_ID"), update=True)
+    if run_info is None:
+        print("No run directories with summary artifacts were found.", file=sys.stderr)
+        return 1
+
+    run_dir = run_info.path
+    rel_run = run_dir.relative_to(REPO_ROOT)
+    print(f"Opening artifacts from {rel_run}")
+
+    opened = False
+    for name in ARTIFACT_NAMES:
+        artifact = run_dir / name
+        if artifact.exists():
+            print(f" - {artifact.relative_to(REPO_ROOT)}")
+            try:
+                _open_with_default_app(artifact)
+            except Exception as exc:  # pragma: no cover - best effort logging
+                print(f"   ! Failed to open {artifact.name}: {exc}", file=sys.stderr)
+            else:
+                opened = True
+        else:
+            print(f" - Missing {name}; skipping.")
+
+    if not opened:
+        print("No artifacts could be opened.", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_latest_setup.py
+++ b/tools/verify_latest_setup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+repo = Path(__file__).resolve().parents[1]
+readme = repo / "README.md"
+makefile = repo / "Makefile"
+tools = repo / "tools"
+
+failures = []
+
+# 1) README checks
+if not readme.exists():
+    failures.append("README.md is missing")
+else:
+    txt = readme.read_text(encoding="utf-8")
+    if "make latest" not in txt:
+        failures.append("README: missing 'make latest' mention")
+    if "make open-artifacts" not in txt:
+        failures.append("README: missing 'make open-artifacts' mention")
+
+# 2) Tools exist
+for p in ["latest_run.py", "open_artifacts.py"]:
+    if not (tools / p).exists():
+        failures.append(f"tools/{p} is missing")
+
+# 3) Makefile checks
+if not makefile.exists():
+    failures.append("Makefile is missing")
+else:
+    mtxt = makefile.read_text(encoding="utf-8")
+    if not re.search(r"^latest:\s*$", mtxt, re.M):
+        failures.append("Makefile: missing 'latest:' target")
+    if not re.search(r"^open-artifacts:\s*", mtxt, re.M):
+        failures.append("Makefile: missing 'open-artifacts:' target")
+    # report depends on latest (e.g., 'report: latest')
+    if not re.search(r"^report:\s*latest\b", mtxt, re.M):
+        failures.append("Makefile: 'report' does not depend on 'latest'")
+
+if failures:
+    print("VERIFICATION: FAIL")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+else:
+    print("VERIFICATION: PASS")
+    print(" - README mentions both targets")
+    print(" - tools/latest_run.py & tools/open_artifacts.py present")
+    print(" - Makefile has targets and 'report: latest' dependency")
+    sys.exit(0)


### PR DESCRIPTION
## Summary
- add helper scripts under tools/ to discover the latest run and open its artifacts
- wire Makefile targets so report depends on latest and expose verify-latest-setup for CI
- add a verify-latest-wiring GitHub Actions workflow that runs the new checker

## Testing
- make verify-latest-setup

------
https://chatgpt.com/codex/tasks/task_e_68cc4a9e0d0c8329aa352154bf8f1e5b