### PR TITLE
Add latest artifacts helpers and wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,18 @@ MODE_ARG := --mode $(MODE)
 MODE_OVERRIDE := $(MODE)
 endif
 
+RESULTS_DIR ?= results
+LATEST_LINK ?= $(RESULTS_DIR)/LATEST
+PYTHON ?= python3
+
 RUN_ID ?= $(shell date -u "+%Y%m%d-%H%M%S")
-RUN_CURRENT := results/.run_id
-RUN_LATEST := results/LATEST
+RUN_CURRENT := $(RESULTS_DIR)/.run_id
 ifeq ($(origin RUN_ID), file)
 ifneq ($(wildcard $(RUN_CURRENT)),)
 RUN_ID := $(shell cat $(RUN_CURRENT))
 endif
 endif
-RUN_DIR := results/$(RUN_ID)
+RUN_DIR := $(RESULTS_DIR)/$(RUN_ID)
 
 TRIALS_ARG :=
 TRIALS_OVERRIDE :=
@@ -79,7 +82,7 @@ test: install demo
 	cp -f results/summary.svg "$$RUN_DIR/" 2>/dev/null || true; \
 	find results -maxdepth 3 -type f -name '*seed*.jsonl' -exec cp -f {} "$$RUN_DIR/" \; 2>/dev/null || true; \
 	cp -f results/summary.md "$$RUN_DIR/" 2>/dev/null || true; \
-	printf "%s\n" "$$RUN_ID" > results/.run_id; \
+	printf "%s\n" "$$RUN_ID" > $(RUN_CURRENT); \
 	printf '🧪 Normalized test artifacts into %s\n' "$$RUN_DIR"; \
 	if [ -x "$(PY)" ]; then \
 	  "$(PY)" -m pytest -q; \
@@ -159,13 +162,12 @@ notes:
 		python scripts/aggregate_results.py --outdir "$(RUN_DIR)"; \
 	fi
 
-report: aggregate plot notes
-	mkdir -p results
-	cp -f "$(RUN_DIR)/summary.csv" results/summary.csv
-	cp -f "$(RUN_DIR)/summary.svg" results/summary.svg
-	cp -f "$(RUN_DIR)/summary.md" results/summary.md
-	cp -f "$(RUN_DIR)/notes.md" results/notes.md 2>/dev/null || true
-	printf "%s\n" "$(RUN_ID)" > $(RUN_LATEST)
+report: aggregate plot notes latest
+	mkdir -p $(RESULTS_DIR)
+	cp -f "$(RUN_DIR)/summary.csv" $(RESULTS_DIR)/summary.csv
+	cp -f "$(RUN_DIR)/summary.svg" $(RESULTS_DIR)/summary.svg
+	cp -f "$(RUN_DIR)/summary.md" $(RESULTS_DIR)/summary.md
+	cp -f "$(RUN_DIR)/notes.md" $(RESULTS_DIR)/notes.md 2>/dev/null || true
 	rm -f $(RUN_CURRENT)
 	if [ -x "$(PY)" ]; then \
 		"$(PY)" scripts/update_readme_results.py; \
@@ -179,7 +181,7 @@ real1:
 	$(MAKE) run SEED=42 TRIALS=5 MODE=REAL
 
 scaffold:
-	mkdir -p adapters attacks defenses filters configs/airline_escalating_v1 results analysis
+	mkdir -p adapters attacks defenses filters configs/airline_escalating_v1 $(RESULTS_DIR) analysis
 
 .PHONY: journal
 journal: install
@@ -196,8 +198,8 @@ ci: install
 
 .PHONY: latest
 latest:
-	@if [ -f $(RUN_LATEST) ]; then \
-		cat $(RUN_LATEST); \
-	else \
-		echo "No published run."; \
-	fi
+	@$(PYTHON) tools/latest_run.py $(RESULTS_DIR) $(LATEST_LINK) || true
+
+.PHONY: open-artifacts
+open-artifacts: latest
+	@$(PYTHON) tools/open_artifacts.py

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _Demo-first companion to ServiceNow/DoomArena. Build tiny, repeatable agent secu
 ## Why this exists
 Teams need **fast iteration** and **CI-friendly artifacts** to reason about agent risks in context. DoomArena-Lab gives you:
 - **Modes**: **SHIM** (simulation adapters) now; **REAL** (upstream DoomArena adapters) when available, with SHIM fallback.
-- **Make UX**: `make demo`, `make xsweep CONFIG=...`, `make report`, `make latest`.
+- **Make UX**: `make demo`, `make xsweep CONFIG=...`, `make report`, `make latest`, `make open-artifacts`.
 - **Artifacts**: Timestamped run dirs under `results/<RUN_DIR>/` with `summary.csv`, `summary.svg`, and (when produced) per-seed JSONL traces.
 - **Metrics/plots**: **Trial-weighted** micro-average ASR in a grouped-bar chart.
 
@@ -18,7 +18,8 @@ make demo
 make report
 
 # 3) Inspect the most recent artifacts (SVG/CSV)
-ls results/LATEST
+make open-artifacts
+# (prints the SVG/CSV paths; also opens them on macOS/Linux)
 ```
 
 Use a specific config:
@@ -62,8 +63,9 @@ results/
 ## Make targets (TL;DR)
 - `make demo` — tiny SHIM sweep to produce a minimal `results/<RUN_DIR>/`.
 - `make xsweep CONFIG=...` — run a configurable sweep.
-- `make report` — asserts `summary.csv` & `summary.svg`; updates `results/LATEST`.
-- `make latest` — prints the run ID pointed to by `results/LATEST` (if present).
+- `make report` — asserts `summary.csv` & `summary.svg`; refreshes `results/LATEST`.
+- `make latest` — refreshes/prints the newest run linked from `results/LATEST`.
+- `make open-artifacts` — ensures `results/LATEST` is set, then prints (and opens) the latest SVG/CSV.
 
 ## CI
 The smoke workflow runs a tiny SHIM sweep and publishes artifacts. It also updates `results/LATEST` for quick inspection in PRs.

--- a/tools/latest_run.py
+++ b/tools/latest_run.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import sys, pathlib
+
+def is_valid_run(d: pathlib.Path) -> bool:
+    return (d / "summary.csv").exists() and (d / "summary.svg").exists()
+
+def newest_run(results: pathlib.Path):
+    if not results.exists():
+        return None
+    cands = [p for p in results.iterdir() if p.is_dir() and p.name != "LATEST"]
+    cands = [p for p in cands if is_valid_run(p)]
+    if not cands:
+        return None
+    cands.sort(key=lambda p: p.stat().st_mtime)
+    return cands[-1]
+
+def main():
+    results = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "results").resolve()
+    link = pathlib.Path(sys.argv[2] if len(sys.argv) > 2 else results / "LATEST")
+    run = newest_run(results)
+    if not run:
+        print(f"No valid run found under {results} (need summary.csv and summary.svg).")
+        return 1
+    # Replace existing symlink/file (avoid removing a real dir)
+    if link.exists() or link.is_symlink():
+        try:
+            if link.is_symlink() or link.is_file():
+                link.unlink()
+        except Exception:
+            pass
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link.symlink_to(run, target_is_directory=True)
+        print(f"UPDATED: {link} -> {run}")
+    except Exception as e:
+        # Fallback pointer file if symlink not allowed
+        pointer = link.parent / "LATEST.path"
+        pointer.write_text(str(run), encoding="utf-8")
+        print(f"Symlink failed ({e}); wrote {pointer} -> {run}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/open_artifacts.py
+++ b/tools/open_artifacts.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import platform, pathlib, subprocess, sys
+
+def opener_cmd():
+    s = platform.system().lower()
+    if "darwin" in s: return ["open"]
+    if "linux" in s: return ["xdg-open"]
+    return None
+
+def resolve_latest(base: pathlib.Path) -> pathlib.Path | None:
+    link = base / "LATEST"
+    pointer = base / "LATEST.path"
+    if link.is_symlink():
+        try: return link.resolve(strict=True)
+        except FileNotFoundError: return None
+    if link.exists() and link.is_dir():
+        return link.resolve()
+    if pointer.exists():
+        t = pathlib.Path(pointer.read_text(encoding="utf-8").strip())
+        return t if t.exists() else None
+    return None
+
+def main():
+    results = pathlib.Path("results").resolve()
+    run = resolve_latest(results)
+    if not run:
+        print("No latest artifacts found. Try: make demo && make report")
+        return 1
+    svg, csv = run / "summary.svg", run / "summary.csv"
+    missing = [p for p in (svg, csv) if not p.exists()]
+    if missing:
+        print("Missing artifacts:", ", ".join(str(m) for m in missing))
+        return 1
+    cmd = opener_cmd()
+    if cmd:
+        try:
+            subprocess.run(cmd + [str(svg)], check=False)
+            subprocess.run(cmd + [str(csv)], check=False)
+        except Exception:
+            pass
+    print(f"SVG: {svg}")
+    print(f"CSV: {csv}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add tooling to link results/LATEST to the newest run and open artifacts
- wire new latest/open-artifacts targets into the Makefile and refresh README guidance

## Testing
- make latest

------
https://chatgpt.com/codex/tasks/task_e_68cc579ff8bc8329ab782978c18cdfe7