### PR TITLE
Add schema v1 tooling and wire into report

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -70,3 +70,5 @@ jobs:
             results/summary.csv
             results/summary.svg
             results/summary.md
+            results/run.json
+            results/LATEST/run.json

--- a/Makefile
+++ b/Makefile
@@ -146,10 +146,13 @@ notes:
 
 report: aggregate plot notes latest
 	mkdir -p $(RESULTS_DIR)
+	# Apply schema v1: add 'schema' column to summary.csv and write run.json
+	python tools/apply_schema_v1.py "$(RUN_DIR)"
 	cp -f "$(RUN_DIR)/summary.csv" $(RESULTS_DIR)/summary.csv
 	cp -f "$(RUN_DIR)/summary.svg" $(RESULTS_DIR)/summary.svg
 	cp -f "$(RUN_DIR)/summary.md" $(RESULTS_DIR)/summary.md
 	cp -f "$(RUN_DIR)/notes.md" $(RESULTS_DIR)/notes.md 2>/dev/null || true
+	cp -f "$(RUN_DIR)/run.json" $(RESULTS_DIR)/run.json 2>/dev/null || true
 	rm -f $(RUN_CURRENT)
 	if [ -x "$(PY)" ]; then \
 		"$(PY)" scripts/update_readme_results.py; \

--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ Each run writes to a timestamped `results/<RUN_DIR>/` directory:
 ```
 results/
   <RUN_DIR>/
+    run.json
     summary.csv
     summary.svg
     ...seed_*.jsonl (optional per-seed traces)
 ```
+
+**Schemas**: each run writes a `run.json` declaring `results_schema` / `summary_schema` (currently `"1"`), and `summary.csv` includes a `schema` column. Bump when columns or semantics change.
 
 **`summary.csv` schema (minimum fields):**
 - `exp` – experiment name

--- a/tests/test_schema_v1.py
+++ b/tests/test_schema_v1.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import csv
+import json
+
+from tools.apply_schema_v1 import ensure_schema_column, write_run_json, SCHEMA_VERSION
+
+
+def _write_csv(p: Path, rows):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+
+
+def test_ensure_schema_column_adds_or_overwrites(tmp_path: Path):
+    csvp = tmp_path / "summary.csv"
+    _write_csv(csvp, [{"exp": "a", "trials": "2", "successes": "1"}])
+    ensure_schema_column(csvp)
+    rows = list(csv.DictReader(csvp.open()))
+    assert "schema" in rows[0]
+    assert rows[0]["schema"] == SCHEMA_VERSION
+
+    # overwrite existing different value
+    _write_csv(csvp, [{"exp": "a", "schema": "old", "trials": "1", "successes": "1"}])
+    ensure_schema_column(csvp)
+    rows = list(csv.DictReader(csvp.open()))
+    assert rows[0]["schema"] == SCHEMA_VERSION
+
+
+def test_write_run_json(tmp_path: Path):
+    write_run_json(tmp_path)
+    data = json.loads((tmp_path / "run.json").read_text())
+    assert data["results_schema"] == SCHEMA_VERSION
+    assert data["summary_schema"] == SCHEMA_VERSION
+    assert isinstance(data["git"], dict)

--- a/tools/apply_schema_v1.py
+++ b/tools/apply_schema_v1.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Apply schema v1 to a results run directory:
+  - Ensure summary.csv has a 'schema' column with value '1'
+  - Write run.json with results/summary schema versions + metadata
+"""
+from __future__ import annotations
+import csv
+import json
+import sys
+import subprocess
+from pathlib import Path
+from datetime import datetime, timezone
+
+SCHEMA_VERSION = "1"
+
+def git_info() -> dict:
+    def run(args):
+        try:
+            return subprocess.check_output(args, stderr=subprocess.DEVNULL).decode().strip()
+        except Exception:
+            return ""
+    return {
+        "sha": run(["git", "rev-parse", "--short", "HEAD"]),
+        "branch": run(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+    }
+
+def ensure_schema_column(csv_path: Path) -> None:
+    if not csv_path.exists():
+        return
+    # read all rows
+    with csv_path.open(newline="") as f:
+        rdr = csv.DictReader(f)
+        rows = list(rdr)
+        fieldnames = [h for h in (rdr.fieldnames or [])]
+    # add 'schema' field if missing
+    if "schema" not in [(h or "") for h in fieldnames]:
+        fieldnames.append("schema")
+        for r in rows:
+            r["schema"] = SCHEMA_VERSION
+    else:
+        # set/overwrite to current version
+        for r in rows:
+            r["schema"] = SCHEMA_VERSION
+    # write back
+    tmp = csv_path.with_suffix(".tmp.csv")
+    with tmp.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+    tmp.replace(csv_path)
+
+def write_run_json(run_dir: Path) -> None:
+    out = {
+        "results_schema": SCHEMA_VERSION,
+        "summary_schema": SCHEMA_VERSION,
+        "run_id": run_dir.name,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "git": git_info(),
+    }
+    (run_dir / "run.json").write_text(json.dumps(out, indent=2), encoding="utf-8")
+
+def main(argv):
+    if len(argv) < 2 or argv[1] in ("-h", "--help"):
+        print("usage: apply_schema_v1.py <RUN_DIR>")
+        return 2
+    run_dir = Path(argv[1]).resolve()
+    ensure_schema_column(run_dir / "summary.csv")
+    write_run_json(run_dir)
+    print(f"Schema v1 applied in {run_dir}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- add a helper to stamp summary.csv with schema v1 and emit run.json metadata for each run
- invoke the schema helper from `make report`, mirror run.json into results, and ship it with smoke artifacts
- document the schema outputs and cover them with unit tests

## Testing
- python -m pytest -q tests/test_schema_v1.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3cd2b46c8329a9f2034e23b8fdef