### PR TITLE
Fix ASR fallback weighting

### DIFF
--- a/scripts/_lib.py
+++ b/scripts/_lib.py
@@ -72,12 +72,21 @@ def weighted_asr_by_exp(rows: Iterable[Dict[str, str]]) -> Dict[str, float]:
                 continue
         except Exception:
             pass
-        # Otherwise fall back to asr/attack_success_rate * trials=1
+        # Otherwise fall back to asr/attack_success_rate * trials (default weight=1)
         asr = r.get("asr") or r.get("attack_success_rate")
         try:
             a = float(asr)
+            weight = 1.0
+            trials_val = r.get("trials")
+            if trials_val is not None:
+                try:
+                    t = float(trials_val)
+                    if t > 0:
+                        weight = t
+                except Exception:
+                    pass
             S, T = acc.get(exp, (0.0, 0.0))
-            acc[exp] = (S + a, T + 1.0)
+            acc[exp] = (S + (a * weight), T + weight)
         except Exception:
             # skip if unusable
             pass

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -46,3 +46,13 @@ def test_weighted_asr_by_exp_weights_trials(tmp_path: Path):
     assert abs(out["a"] - 0.5) < 1e-9
     assert abs(out["b"] - 0.75) < 1e-9
 
+
+def test_weighted_asr_by_exp_fallback_uses_trials(tmp_path: Path):
+    rows = [
+        {"exp": "a", "asr": "0.1", "trials": "10"},
+        {"exp": "a", "asr": "0.5", "trials": "2"},
+    ]
+    _write_csv(tmp_path, rows)
+    out = weighted_asr_by_exp(read_summary(tmp_path / "summary.csv"))
+    assert abs(out["a"] - (0.1 * 10 + 0.5 * 2) / 12) < 1e-9
+


### PR DESCRIPTION
## Summary
- weight ASR fallback rows by their reported trial counts
- add regression test to cover trial-weighted fallback aggregation

## Testing
- pytest tests/test_lib.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cd61c3c7e48329a0d8a6c0252ad2b8