### PR TITLE
Harden open artifacts tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ latest:
 	@$(PYTHON) tools/latest_run.py $(RESULTS_DIR) $(LATEST_LINK) || true
 
 .PHONY: open-artifacts
-# Open latest summary.svg and summary.csv (prints paths in CI)
-open-artifacts:
-	@$(MAKE) latest
-	@$(PYTHON) tools/open_artifacts.py
+# Open latest summary.svg and summary.csv.
+# Default is print-only (safe in CI). Pass `--open` locally if you want it to launch viewers.
+open-artifacts: latest
+	@$(PYTHON) tools/open_artifacts.py --results "$(RESULTS_DIR)/LATEST"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ results/
 - `make xsweep CONFIG=...` — run a configurable sweep.
 - `make report` — asserts `summary.csv` & `summary.svg`; refreshes `results/LATEST`.
 - `make latest` — refreshes/prints the newest run linked from `results/LATEST`.
-- `make open-artifacts` — ensures `results/LATEST` is set, then prints (and opens) the latest SVG/CSV.
+- `make open-artifacts` — prints paths to `results/LATEST/summary.svg` and `summary.csv` (safe in CI).  \
+  Add `--open` locally to launch files: `python tools/open_artifacts.py --open`.
 
 ### Testing
 - ✅ `make test-unit` — runs fast unit tests inside `.venv`

--- a/tools/open_artifacts.py
+++ b/tools/open_artifacts.py
@@ -1,45 +1,47 @@
 #!/usr/bin/env python3
-import platform, pathlib, subprocess, sys
+from __future__ import annotations
+import argparse, subprocess, sys
+from pathlib import Path
 
-def opener_cmd():
-    s = platform.system().lower()
-    if "darwin" in s: return ["open"]
-    if "linux" in s: return ["xdg-open"]
-    return None
+def can_run(cmd: str) -> bool:
+    from shutil import which
+    return which(cmd) is not None
 
-def resolve_latest(base: pathlib.Path) -> pathlib.Path | None:
-    link = base / "LATEST"
-    pointer = base / "LATEST.path"
-    if link.is_symlink():
-        try: return link.resolve(strict=True)
-        except FileNotFoundError: return None
-    if link.exists() and link.is_dir():
-        return link.resolve()
-    if pointer.exists():
-        t = pathlib.Path(pointer.read_text(encoding="utf-8").strip())
-        return t if t.exists() else None
-    return None
+def try_open(p: Path) -> None:
+    # Best-effort open for local dev; ignore errors in headless CI
+    if sys.platform == "darwin" and can_run("open"):
+        subprocess.Popen(["open", str(p)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    elif sys.platform.startswith("linux") and can_run("xdg-open"):
+        subprocess.Popen(["xdg-open", str(p)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-def main():
-    results = pathlib.Path("results").resolve()
-    run = resolve_latest(results)
-    if not run:
-        print("No latest artifacts found. Try: make demo && make report")
-        return 1
-    svg, csv = run / "summary.svg", run / "summary.csv"
-    missing = [p for p in (svg, csv) if not p.exists()]
-    if missing:
-        print("Missing artifacts:", ", ".join(str(m) for m in missing))
-        return 1
-    cmd = opener_cmd()
-    if cmd:
-        try:
-            subprocess.run(cmd + [str(svg)], check=False)
-            subprocess.run(cmd + [str(csv)], check=False)
-        except Exception:
-            pass
-    print(f"SVG: {svg}")
-    print(f"CSV: {csv}")
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--results", default="results/LATEST", help="results directory (default: results/LATEST)")
+    ap.add_argument("--open", action="store_true", help="attempt to open files instead of just printing paths")
+    ap.add_argument("--strict", action="store_true", help="exit non-zero if artifacts are missing")
+    args = ap.parse_args(argv)
+
+    root = Path(args.results)
+    svg = root / "summary.svg"
+    csvp = root / "summary.csv"
+
+    if not root.exists():
+        msg = f"[open-artifacts] No results to open: '{root}' does not exist. Run `make report` or `make demo` first."
+        print(msg)
+        return 1 if args.strict else 0
+
+    found_any = False
+    for p in (svg, csvp):
+        if p.exists():
+            found_any = True
+            print(f"[open-artifacts] {p.resolve()}")
+            if args.open:
+                try_open(p)
+        else:
+            print(f"[open-artifacts] missing: {p}")
+
+    if not found_any:
+        return 1 if args.strict else 0
     return 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `tools/open_artifacts.py` print helpful hints when results are missing and gate viewer launches behind `--open`
- wire the `open-artifacts` Make target to print artifact paths from `results/LATEST`
- document the print-only default and optional open flag in the README

## Testing
- `make open-artifacts`
- `python3 tools/verify_latest_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd6d3b659c8329aa6dbd4d526aa8eb