### PR TITLE
Restore verify latest targets and help docs

### DIFF
--- a/.codex/note_pr29.txt
+++ b/.codex/note_pr29.txt
@@ -1,0 +1,2 @@
+Sync PR #29 branch with main: ensure bare 'latest:' and 'open-artifacts:' labels,
+keep help target, and align README wording with current behavior.

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ifneq ($(origin EXP), file)
 EXP_OVERRIDE := $(EXP)
 endif
 
-venv: ## Create local virtualenv
+venv: ## Create local virtualenv in .venv
 	python -m venv $(VENV)
 	$(PY) -m pip install -U pip
 
@@ -192,7 +192,11 @@ latest:
 	@$(PYTHON) tools/latest_run.py $(RESULTS_DIR) $(LATEST_LINK) || true
 
 .PHONY: open-artifacts
-# Open latest summary.svg and summary.csv.
-# Default is print-only (safe in CI). Pass `--open` locally if you want it to launch viewers.
+# Open latest summary.svg and summary.csv (print-only; safe in CI)
 open-artifacts: latest
 	@$(PYTHON) tools/open_artifacts.py --results "$(RESULTS_DIR)/LATEST"
+
+.PHONY: help
+help: ## List common targets and brief docs
+	@echo "DoomArena-Lab — common targets:"; \
+	grep -E '^[a-zA-Z0-9_-]+:.*?## ' $(firstword $(MAKEFILE_LIST)) | sed 's/:.*## / — /' | sort

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ results/
 - `make demo` — tiny SHIM sweep to produce a minimal `results/<RUN_DIR>/`.
 - `make xsweep CONFIG=...` — run a configurable sweep.
 - `make report` — asserts `summary.csv` & `summary.svg`; refreshes `results/LATEST`.
-- `make latest` — refreshes/prints the newest run linked from `results/LATEST`.
+- `make latest` — refreshes `results/LATEST` to the newest run with `summary.csv` & `summary.svg`.
 - `make open-artifacts` — prints paths to `results/LATEST/summary.svg` and `summary.csv` (safe in CI).  \
   Add `--open` locally to launch files: `python tools/open_artifacts.py --open`.
 


### PR DESCRIPTION
## Summary
- ensure the `latest` and `open-artifacts` make targets stay bare for the verify workflow while keeping updated comments
- restore a documented `help` target and refresh the virtualenv target description
- align README CI notes and add a PR syncing note under `.codex/`

## Testing
- make help

------
https://chatgpt.com/codex/tasks/task_e_68cd6f46f3048329bff4e237c402a1fc