### PR TITLE
Add architecture and experiments documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ results/
 - `make latest` — refreshes `results/LATEST` to the newest run with `summary.csv` & `summary.svg`.
 - `make open-artifacts` — prints paths to `results/LATEST/summary.svg` and `summary.csv` (safe in CI). Add `--open` locally to launch files: `python tools/open_artifacts.py --open`.
 
+## Docs
+- [Architecture](docs/ARCHITECTURE.md) — data flow, contracts, schemas, CI
+- [Experiments](docs/EXPERIMENTS.md) — add/run configs, thresholds, tips
+
 ### Testing
 - ✅ `make test-unit` — runs fast unit tests inside `.venv`
 - ✅ `make test` — runs all tests inside `.venv`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,40 @@
+# DoomArena-Lab Architecture (builder view)
+
+## Purpose
+Decision-ready demos & guardrails for agent teams. Fast local runs, artifact-first CI.
+
+## Data flow
+```
+configs/*/run.yaml ──▶ scripts/xsweep.py ──▶ results/<RUN_DIR>/
+                             │
+                             ├─ per-seed traces (*.jsonl) [optional]
+                             ├─ summary.csv  (trial-weighted, schema=1)
+                             ├─ summary.svg  (grouped bars)
+                             ├─ run.json     (results_schema/summary_schema=1, git, timestamps)
+                             └─ notes.md     (auto notes, optional)
+                                     │
+                                     ▼
+make report ──▶ results/LATEST/ (mirror) + index.html (mini report)
+                              ▲
+                              └─ tools/latest_run.py picks newest valid run
+```
+
+## Contracts (keep stable)
+- **summary.csv**: must include `exp`, `trials`, `successes`, `asr` (trial-weighted preferred); `schema` column set to `"1"`.
+- **run.json**: includes `results_schema` and `summary_schema` (currently `"1"`), `run_id`, UTC timestamp, `git.sha`, `git.branch`.
+- **LATEST**: symlink/marker to most recent run with valid `summary.csv` & `summary.svg`.
+
+## CLI & orchestration
+- `make demo` — quick SHIM runs to populate artifacts.
+- `make xsweep CONFIG=...` — configurable sweep.
+- `make report` — applies schema v1, builds HTML report, refreshes LATEST.
+- `make latest`, `make open-artifacts` — convenience for inspection.
+- CI: **smoke** (tiny SHIM sweep, uploads artifacts) + PR comment with schema + thresholds table.
+
+## Thresholds (governance)
+- `thresholds.yaml` supports `min_trials`, `max_asr`, `min_asr`. CI posts PASS/WARN/FAIL (warn-only default).
+
+## Tech shape (keep it light)
+- `scripts/_lib.py` centralizes CSV reading, weighting, git/time helpers.
+- Thin scripts in `scripts/`; Makefile is the user interface.
+- No heavy deps; pandas used only where helpful.

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -1,0 +1,34 @@
+# Adding & Running Experiments
+
+## 1) Add a config
+Create `configs/<exp_name>/run.yaml` (see existing examples under `configs/`).
+
+## 2) Run locally
+```bash
+make xsweep CONFIG=configs/<exp_name>/run.yaml SEEDS="11,12" TRIALS=3 MODE=SHIM
+make report
+make open-artifacts   # prints paths to summary.svg/csv
+```
+You’ll get:
+- `results/<RUN_DIR>/summary.csv` (with `schema=1`)
+- `results/<RUN_DIR>/summary.svg`
+- `results/<RUN_DIR>/run.json`
+- `results/LATEST/index.html` (mini HTML report)
+
+## 3) Compare or repeat
+- Re-run with different seeds/trials or MODE=REAL (falls back to SHIM).
+- `make latest` refreshes the pointer if you create multiple runs.
+
+## 4) Thresholds (optional policy)
+Edit `thresholds.yaml` to set guardrails:
+```yaml
+<exp_name>:
+  min_trials: 10
+  max_asr: 0.25
+```
+CI will post PASS/WARN/FAIL in the PR comment.
+
+## 5) Tips
+- `make help` — discover targets
+- `make vars` — see effective EXP/TRIALS/SEEDS/MODE/RUN_ID
+- Keep outputs schema-compatible; bump schema if columns/semantics change.


### PR DESCRIPTION
## Summary
- add builder-focused architecture documentation covering data flow, contracts, and tooling
- document the workflow for adding and running experiments end-to-end
- link the new docs from the README for easy discovery

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cd952c779083299a892316c5f11155