### PR TITLE
Add list-runs helper and upload full run artifacts

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -24,18 +24,32 @@ jobs:
           python-version: "3.11"
       - name: Install
         run: make install
-      - name: Run demo sweep(s)
+      - name: Run demo (single RUN_ID with both experiments)
+        id: run-info
         env:
           TRIALS: ${{ inputs.trials }}
           SEEDS: ${{ inputs.seeds }}
           MODE: ${{ inputs.mode }}
         run: |
-          make xsweep CONFIG=configs/airline_escalating_v1/run.yaml EXP=airline_escalating_v1 TRIALS="${TRIALS}" SEEDS="${SEEDS}" MODE="${MODE}"
-          make xsweep CONFIG=configs/airline_static_v1/run.yaml     EXP=airline_static_v1     TRIALS="${TRIALS}" SEEDS="${SEEDS}" MODE="${MODE}"
+          RUN_ID="$(date -u '+%Y%m%d-%H%M%S')"
+          echo "RUN_ID=$RUN_ID"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          make xsweep CONFIG=configs/airline_escalating_v1/run.yaml EXP=airline_escalating_v1 TRIALS="${TRIALS}" SEEDS="${SEEDS}" MODE="${MODE}" RUN_ID="$RUN_ID"
+          make xsweep CONFIG=configs/airline_static_v1/run.yaml     EXP=airline_static_v1     TRIALS="${TRIALS}" SEEDS="${SEEDS}" MODE="${MODE}" RUN_ID="$RUN_ID"
       - name: Report + publish LATEST
+        env:
+          RUN_ID: ${{ steps.run-info.outputs.run_id }}
         run: |
-          make report
+          make report RUN_ID="${RUN_ID}"
           make latest
+      - name: Upload full RUN_DIR
+        if: steps.run-info.outputs.run_id != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: run-${{ steps.run-info.outputs.run_id }}
+          path: results/${{ steps.run-info.outputs.run_id }}/
+          if-no-files-found: error
+          retention-days: 7
       - name: Upload latest artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #   RUN_ID  ?= (timestamp default)     # results/<RUN_ID>; persisted via results/.run_id
 # ------------------------------------------------------------------------------
 
-.PHONY: venv install test run sweep aggregate report scaffold check-schema plot notes sweep3 real1 xrun xsweep xsweep-all topn demo test-unit ci latest open-artifacts journal install-tau help vars
+.PHONY: venv install test run sweep aggregate report scaffold check-schema plot notes sweep3 real1 xrun xsweep xsweep-all topn demo test-unit ci latest open-artifacts list-runs journal install-tau help vars
 
 SHELL := /bin/bash
 
@@ -203,6 +203,22 @@ latest:
 
 open-artifacts: latest
 	@$(PYTHON) tools/open_artifacts.py --results "$(RESULTS_DIR)/LATEST"
+
+.PHONY: list-runs
+list-runs: ## List timestamped results/<RUN_ID> folders and whether CSV/SVG exist
+	@if [ ! -d "$(RESULTS_DIR)" ]; then \
+		printf "No runs found in %s\n" "$(RESULTS_DIR)"; \
+	else \
+		printf "%-35s  %-3s  %-3s  %-5s %s\n" "RUN_DIR" "CSV" "SVG" "NOTES" "SIZE"; \
+                find "$(RESULTS_DIR)" -mindepth 1 -maxdepth 1 -type d -name "20*" | sort | while read -r d; do \
+                        test -f "$$d/summary.csv" && c=✓ || c=×; \
+                        test -f "$$d/summary.svg" && s=✓ || s=×; \
+                        test -f "$$d/notes.md" && n=✓ || n=×; \
+                        sz=$$(du -sh "$$d" 2>/dev/null | cut -f1); \
+                        [ -n "$$sz" ] || sz=-; \
+                        printf "%-35s  %-3s  %-3s  %-5s %s\n" "$${d#$(RESULTS_DIR)/}" "$$c" "$$s" "$$n" "$$sz"; \
+                done; \
+        fi
 
 .PHONY: help
 help: ## List common targets and brief docs


### PR DESCRIPTION
## Summary
- add a list-runs Make target to summarize timestamped results directories and surface file availability
- capture the RUN_ID in the run-demo workflow and upload the corresponding results/<RUN_ID> directory alongside the latest artifacts

## Testing
- make list-runs

------
https://chatgpt.com/codex/tasks/task_e_68cd9fdb94f48329b7cbdb981c38401b