### PR TITLE
Fix RUN_ID propagation in run-demo workflow

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -42,20 +42,20 @@ jobs:
           TRIALS: ${{ inputs.trials }}
           SEEDS: ${{ inputs.seeds }}
           MODE: ${{ inputs.mode }}
-          RUN_ID: ${{ env.RUN_ID }}
+          RUN_ID: ${{ steps.set-run-id.outputs.run_id }}
         run: |
           make demo TRIALS="${TRIALS}" SEEDS="${SEEDS}" MODE="${MODE}" RUN_ID="${RUN_ID}"
 
       - name: Report + publish LATEST
         env:
-          RUN_ID: ${{ env.RUN_ID }}
+          RUN_ID: ${{ steps.set-run-id.outputs.run_id }}
         run: |
           make report RUN_ID="${RUN_ID}"
           make latest
 
       - name: Add timestamped copies inside run dir
         env:
-          RUN_ID: ${{ env.RUN_ID }}
+          RUN_ID: ${{ steps.set-run-id.outputs.run_id }}
         run: |
           d="results/${RUN_ID}"
           test -d "$d" || { echo "Missing $d"; exit 1; }
@@ -69,8 +69,8 @@ jobs:
         if: ${{ steps.set-run-id.outputs.run_id != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: run-${{ env.RUN_ID }}
-          path: results/${{ env.RUN_ID }}/
+          name: run-${{ steps.set-run-id.outputs.run_id }}
+          path: results/${{ steps.set-run-id.outputs.run_id }}/
           if-no-files-found: error
           retention-days: 7
 


### PR DESCRIPTION
## Summary
- use the recorded run id output when exporting RUN_ID for subsequent steps
- ensure artifact naming and paths rely on the single pinned RUN_ID

## Testing
- not run (CI workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68cdab1dd40c8329a9e95aa4c9b7d6f1