### PR TITLE
chore: tidy run artifacts

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -42,35 +42,29 @@ jobs:
           TRIALS: ${{ inputs.trials }}
           SEEDS: ${{ inputs.seeds }}
           MODE: ${{ inputs.mode }}
-          RUN_ID: ${{ steps.set-run-id.outputs.run_id }}
+          RUN_ID: ${{ env.RUN_ID }}
         run: |
           make demo TRIALS="${TRIALS}" SEEDS="${SEEDS}" MODE="${MODE}" RUN_ID="${RUN_ID}"
 
       - name: Report + publish LATEST
         env:
-          RUN_ID: ${{ steps.set-run-id.outputs.run_id }}
+          RUN_ID: ${{ env.RUN_ID }}
         run: |
           make report RUN_ID="${RUN_ID}"
           make latest
 
-      - name: Add timestamped copies inside run dir
+      - name: Tidy run directory (remove duplicates)
         env:
-          RUN_ID: ${{ steps.set-run-id.outputs.run_id }}
+          RUN_ID: ${{ env.RUN_ID }}
         run: |
-          d="results/${RUN_ID}"
-          test -d "$d" || { echo "Missing $d"; exit 1; }
-          for f in summary.csv summary.svg summary.md index.html run.json; do
-            if [ -f "$d/$f" ]; then
-              cp -f "$d/$f" "$d/${f%.*}_${RUN_ID}.${f##*.}"
-            fi
-          done
+          make tidy-run RUN_ID="${RUN_ID}"
 
       - name: Upload full RUN_DIR
         if: ${{ steps.set-run-id.outputs.run_id != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: run-${{ steps.set-run-id.outputs.run_id }}
-          path: results/${{ steps.set-run-id.outputs.run_id }}/
+          name: run-${{ env.RUN_ID }}
+          path: results/${{ env.RUN_ID }}/
           if-no-files-found: error
           retention-days: 7
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #   RUN_ID  ?= (timestamp default)     # results/<RUN_ID>; persisted via results/.run_id
 # ------------------------------------------------------------------------------
 
-.PHONY: venv install test run sweep aggregate report scaffold check-schema plot notes sweep3 real1 xrun xsweep xsweep-all topn demo test-unit ci latest open-artifacts list-runs journal install-tau help vars
+.PHONY: venv install test run sweep aggregate report scaffold check-schema plot notes sweep3 real1 xrun xsweep xsweep-all topn demo test-unit ci latest tidy-run open-artifacts list-runs journal install-tau help vars
 
 SHELL := /bin/bash
 
@@ -200,6 +200,15 @@ ci: install ## CI entrypoint: minimal sweep & report (used in smoke)
 .PHONY: latest
 latest:
 	@$(PYTHON) tools/latest_run.py $(RESULTS_DIR) $(LATEST_LINK) || true
+
+tidy-run: ## Remove redundant files in results/$(RUN_ID) (timestamped copies, PNG)
+	@d="results/$(RUN_ID)"; \
+	if [ -d "$$d" ]; then \
+	  rm -f "$$d"/index_* "$$d"/summary_*.csv "$$d"/summary_*.svg "$$d"/summary_*.md "$$d"/run_*.json "$$d"/summary.png 2>/dev/null || true; \
+	  echo "Tidied $$d"; \
+	else \
+	  echo "No run dir at $$d"; \
+	fi
 
 open-artifacts: latest
 	@$(PYTHON) tools/open_artifacts.py --results "$(RESULTS_DIR)/LATEST"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ _Demo-first companion to ServiceNow/DoomArena. Build tiny, repeatable agent secu
 Teams need **fast iteration** and **CI-friendly artifacts** to reason about agent risks in context. DoomArena-Lab gives you:
 - **Modes**: **SHIM** (simulation adapters) now; **REAL** (upstream DoomArena adapters) when available, with SHIM fallback.
 - **Make UX**: `make demo`, `make xsweep CONFIG=...`, `make report`, `make latest`, `make open-artifacts`.
-- **Artifacts**: Timestamped run dirs under `results/<RUN_DIR>/` with `summary.csv`, `summary.svg`, and (when produced) per-seed JSONL traces.
+- **Artifacts**:
+  - Each run produces a timestamped folder under `results/<RUN_ID>/` (canonical files only: `index.html`, `summary.csv/.svg/.md`, `run.json`, `notes.md`, and per-experiment folders).
+  - `results/` also contains convenience “latest” copies for quick viewing.
+  - The `run-demo` action uploads **two artifacts**: `latest-artifacts` and the slimmed full folder `run-<RUN_ID>`.
 - **Metrics/plots**: **Trial-weighted** micro-average ASR in a grouped-bar chart (via a tiny shared helper in `scripts/_lib.py`).
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- add a tidy-run make target to clean timestamped duplicates before upload
- update the run-demo workflow to reuse the job RUN_ID and tidy the run directory
- document the canonical files kept in run artifacts

## Testing
- make tidy-run RUN_ID=test

------
https://chatgpt.com/codex/tasks/task_e_68cdaf270a40832981a0dd5fb6eb2965