### PR TITLE
Refresh backlog for REAL MVP track

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,121 +1,65 @@
-# Backlog — DoomArena-Lab (refresh: 2025-09-18)
+# Backlog
 
-## Product vision (builder-focused)
-A lightweight **harness around ServiceNow/DoomArena** that turns agent evaluations into
-**CI-grade, decision-ready artifacts** for product & governance. Run fast with **SHIM**
-today; swap to **REAL** adapters when present; always publish **stable, versioned outputs**.
+## Goals (north star)
+- Ship an **e2e-running** lab that produces small, repeatable experiments with CI-friendly artifacts.
+- Support **SHIM** sims for fast iteration **and** a path to **REAL** adapters (first MVP: one cloud model).
+- Keep the repo light/approachable: Makefile “buttons”, thin scripts, minimal deps, artifacts you can paste in PRs.
 
-**Primary users:** product / eng teams shipping agents (not researcher-only workflows).  
-**Non-goals (for now):** heavy plugin systems, big new deps, replacing DoomArena research surface,
-multiple slow CI gates. Keep it light and pragmatic.
+## Near-term (2–5 days, e2e-first)
+1) **Run-demo one-click E2E** (CI) — ✅
+   - `Actions → run-demo`: runs two SHIM configs, publishes `results/LATEST/*`, uploads `run-<RUN_ID>/` artifact.
+   - Pinned `RUN_ID` across steps; artifacts slimmed (no dup timestamped files). ✅
+2) **Artifacts hygiene** — ✅
+   - Canonical files only in `results/<RUN_ID>/`: `index.html`, `summary.{csv,svg,md}`, `run.json`, `notes.md`, per-exp folders.
+   - Convenience copies live in `results/LATEST/*`.
+3) **Makefile UX** — ✅ (new/updated)
+   - `help`, `vars`, `latest`, `open-artifacts`, `list-runs`, `tidy-run` (remove redundancies).
+4) **Docs parity** — ✅
+   - README Quick Start reflects `run-demo`, artifacts policy, and E2E story.
 
-**Decision-ready means:** timestamped runs; a `results/LATEST/` pointer; CSV/SVG/HTML summaries
-anyone can read; PR comments; (soon) thresholds for red/green gates.
+## Next up (to real MVP)
+### A. REAL MVP (first cloud model) — **priority**
+**Why**: E2E without an actual model isn’t a true MVP. We need one “REAL” lane to prove value for product/governance teams.
+**Definition of done**:
+- `MODE=REAL` path exists for one exp (e.g., `airline_static_v1`).
+- Thin adapter module (no heavy framework): takes prompt(s) → calls provider → returns text.
+- Configurable via `configs/<exp>/run.yaml` with `provider`, `model`, and `env var` key names.
+- Local: developer runs `make demo MODE=REAL` using env vars.
+- CI (optional, non-required): a **manual** workflow `run-real-mvp` that reads `secrets.*` and uploads artifacts (not a required check).
+**Tasks**:
+1. `adapters/real_client.py` (tiny):
+   - `class RealClient(provider:str, model:str, api_key_env:str)` with `generate(prompt:str) -> str`.
+   - Provider-agnostic shim; implement one provider first (HTTP POST), errors become failed trials.
+2. Wire REAL into `scripts/run_experiment.py`:
+   - If `MODE=REAL`, instantiate `RealClient` from config; SHIM path unchanged.
+3. Config + secrets:
+   - Add fields to `configs/airline_static_v1/run.yaml`: `provider`, `model`, `api_key_env`.
+   - README snippet: export env var locally; GitHub Actions: inputs map to `${{ secrets.* }}` for **manual** workflow.
+4. Workflow:
+   - New `.github/workflows/run-real-mvp.yml` (workflow_dispatch): install → `make demo MODE=REAL` (with safe default TRIALS=1, SEEDS=1) → `make report latest` → upload artifacts. Not required for PRs.
+5. Guardrails:
+   - Timeouts/retries in adapter; redact secrets from logs; cap tokens/price via config.
 
----
+### B. Test coverage on behavior (fast)
+1. Unit test for trial-weighted micro-average in `scripts/_lib.py`. ✅ basic added; extend with edge-cases (0 trials, mixed seeds).
+2. “Smoke+assert” on CSV header & non-empty rows for SHIM/REAL E2E (behind an env flag for REAL).
 
-## Done (Sep 17–18)
-- ✅ README: product vision + demo-first Quick Start.
-- ✅ Latest artifacts: `results/LATEST` symlink; `make latest`, `make open-artifacts`.
-- ✅ Report path: `report` refreshes `LATEST`; grouped-bar chart uses trial-weighted ASR.
-- ✅ Verifier: `tools/verify_latest_setup.py` + **verify-latest-wiring** workflow.
-- ✅ Smoke CI (PR/main): tiny SHIM demo → `report` → upload artifacts → PR comment (ASR table).
-- ✅ Hardening: `tools/plot_safe.py` writes placeholder SVG when CSV has no rows.
-- ✅ Journal + repo hygiene: conflicts resolved; stale PRs closed; Actions green.
+### C. Developer UX polish (quick wins)
+1. `make quickstart` — `install → demo → report → open-artifacts` (exists). Expand README.
+2. `make list-runs` formatting tweaks (column widths) — optional.
+3. `make vars` prints effective config incl. MODE/RUN_ID (exists).
 
----
+## Tech debt (keep light)
+**We keep speed, but centralize the sharp bits:**
+1) **Shared helpers** — ✅ `scripts/_lib.py` (CSV read, weighted ASR, ensure_dir, now_iso/git_info).
+2) **Explicit contracts** — Add `summary_schema: 1`, `results_schema: 1` (in CSV, run.json). ✅
+3) **Docs (1 page each)** — ✅ `docs/ARCHITECTURE.md`, `docs/EXPERIMENTS.md`. Keep tiny.
+4) **Makefile help/vars** — ✅ self-documenting.
+5) **Don’t** package-ify yet; wait for second REAL provider to emerge before extracting a package.
 
-## NOW / NEXT (detailed specs)
+## Done / Recently shipped
+- `run-demo` (pinned RUN_ID, slim artifacts), `list-runs`, `tidy-run`, LATEST pointer helpers, README refresh.
 
-### A. Shared helpers to remove duplication (`scripts/_lib.py`) — *in motion*
-**Why:** multiple `scripts/*.py` repeat CSV reading, header normalization, ASR math, and path utils.  
-**Do:**
-- `scripts/_lib.py` (pure stdlib):
-  - `read_summary(path) -> list[dict]` (lower-case headers; cast `trials/successes/asr` when possible)
-  - `weighted_asr_by_exp(rows) -> dict[str,float]` (trial-weighted)
-  - `ensure_dir(path)`, `now_iso()`, `git_info() -> {sha, branch}`
-- Refactor `plot_results.py` (done in branch) and then `aggregate_results.py`, `update_readme_*`, `auto_notes` to import `_lib`.
-**Acceptance:**
-- Unit tests: header normalization & weighting math pass; no duplicate logic left (grep).
-- `make demo && make report` unchanged outputs; Actions green.
-**Estimate:** M  
-**Notes:** keep helpers tiny; no new deps.
-
-### B. Explicit schema versioning (results + summary)
-**Why:** future changes shouldn’t silently break old runs; governance needs declared versions.  
-**Do:**
-- Add `schema` column with value `"1"` to `summary.csv`.
-- Emit per-run `run.json` with:  
-  `{"results_schema":"1","summary_schema":"1","run_id":..., "generated_at": now_iso(), "git": git_info()}`
-- Readers in `_lib` tolerate missing/older fields.
-**Acceptance:**
-- `make demo && make report` yields `summary.csv` with `schema` and a `run.json` in each run dir.
-- README mentions schema fields; verifier optionally checks presence.
-**Estimate:** S
-
-### C. Makefile UX polish (self-documenting)
-**Why:** faster onboarding; fewer “how do I…?” questions.  
-**Do:**
-- Document overridable vars at top (EXP, TRIALS, SEEDS, MODE, RUN_ID) with defaults.
-- Add `help` target that lists targets from `##` comments. Example:
-  ```
-  .PHONY: help
-  help: ## List targets and brief docs
-  @grep -E '^[a-zA-Z0-9_-]+:.*## ' Makefile | sed 's/:.*## / — /'
-  ```
-- Ensure consistent env: rely on `$(PY)`/`.venv` uniformly.
-- Remove duplicate rules (single `latest`/`open-artifacts`).
-**Acceptance:** `make help` shows a tidy list; no duplicate-target warnings; CI green.  
-**Estimate:** S
-
-### D. Mini HTML report per run (`index.html`)
-**Why:** one-click artifact for PM/risk reviewers (no notebook required).  
-**Do:**
-- `tools/mk_report.py` generates `results/<RUN_DIR>/index.html` from CSV/SVG + mirrors to `results/LATEST/index.html`.
-- Include in smoke artifacts; link from PR comment.
-**Acceptance:** HTML exists for each run; opens with SVG and ASR table locally & from artifacts.  
-**Estimate:** S
-
-### E. Behavior-first tests (unit + smoke add-on)
-**Why:** protect math/IO behavior, not filenames.  
-**Do:**
-- Unit: `weighted_asr_by_exp` with mixed trial counts; `read_summary` header normalization.
-- Smoke: assert placeholder SVG present when CSV has 0 rows.
-**Acceptance:** `pytest -q` green; smoke still fast; breaking math fails tests.  
-**Estimate:** S
-
-### F. Governance-ready hooks (thresholds / gates)
-**Why:** turn artifacts into actionable “go/no-go” signals for PRs and reviews.  
-**Do (phase 1):**
-- Support optional `thresholds.yaml` (per experiment): `min_trials`, `max_asr` (or `min_pass_rate` for defenses).
-- Add `tools/check_thresholds.py` to parse `results/LATEST/summary.csv` and return non-zero on violation; print a short table.
-- Wire optional step in smoke (“warn only” now; no required gate yet).
-**Acceptance:** On PRs with thresholds present, workflow posts a status comment with pass/fail per experiment.  
-**Estimate:** M  
-**Later (phase 2):** make it a required gate once teams are comfortable.
-
-### G. Docs: Architecture & Experiments
-**Why:** clarify contracts; speed contributions.  
-**Do:**
-- `docs/ARCHITECTURE.md`: ASCII data-flow (config → xsweep → aggregate → plot → publish), schema versions location, `results/LATEST` contract.
-- `docs/EXPERIMENTS.md`: how to add configs, run locally, interpret outputs, compare runs; SHIM↔REAL swap/fallback.
-- Link both near top of README.
-**Acceptance:** pages render; links work; newbies can follow unaided.  
-**Estimate:** S
-
----
-
-## Later (intentional deferrals)
-- Packaging/plug-in systems; heavy deps (Pydantic/Pandas) unless needed.
-- Multiple slow CI jobs; keep a single “smoke” required for speed.
-- Advanced visual dashboards (consider after HTML report proves useful).
-
----
-
-## Sequencing (suggested)
-1) **A. Shared helpers** → 2) **E. Tests** → 3) **B. Schemas** → 4) **C. Makefile UX** → 5) **D. HTML report** → 6) **F. Governance hooks** → 7) **G. Docs**
-
-## Definition of Done (per item)
-- Merged to `main`; smoke + verifier green.
-- If outputs change: schema bumped, readers tolerant; README/Docs updated.
-- PR comment and artifacts remain useful to non-coders.
+## Nice-to-have (later)
+- Optional HTML report enhancements (per-exp drill-down links to per-seed JSONL if produced).
+- CI matrix for multiple SHIM configs (kept optional to stay fast).


### PR DESCRIPTION
## Summary
- rewrite docs/backlog.md around an e2e-first plan with a clearly defined REAL MVP track
- capture current near-term wins and reorganize upcoming work into REAL/test/UX/tech-debt buckets

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cdb2e720988329ac1bfb346b3e9e85