### PR TITLE
Add policy gate for REAL experiment runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ make demo && make report
 - **SHIM** — simulation adapters for quick, deterministic demos.
 - **REAL** — first MVP will integrate a single cloud model via a thin adapter and env-based credentials (manual workflow; optional in CI). The lab falls back to SHIM if REAL is not configured.
 
+## Policy tags & routing
+- Add `policy: benign|sensitive|prohibited` to each experiment config.
+- Only `benign` experiments will hit REAL providers by default.
+- Marking a config `policy: sensitive` routes MODE=REAL → SHIM unless you export `ALLOW_SENSITIVE=1`.
+- `policy: prohibited` always runs via SHIM. Each run records the decision in `results/<RUN_ID>/run.json`.
+
 ## Make targets (TL;DR)
 - `make help` — list common targets & docs.
 - `make demo` — tiny sweep (defaults to SHIM) producing `results/<RUN_ID>/`.

--- a/configs/airline_escalating_v1/exp.yaml
+++ b/configs/airline_escalating_v1/exp.yaml
@@ -2,6 +2,7 @@ exp: airline_escalating_v1
 mode: SHIM        # REAL|SHIM (REAL may fallback to SHIM)
 trials: 5
 seeds: [41, 42, 43]
+policy: benign
 attack:
   name: escalating_dialogue_v1
   max_turns: 3

--- a/configs/airline_escalating_v1/run.yaml
+++ b/configs/airline_escalating_v1/run.yaml
@@ -1,6 +1,7 @@
 seed: 42
 trials: 20
 online: false
+policy: benign
 attack:
   type: escalating_dialogue
   levels:

--- a/configs/airline_static_v1/run.yaml
+++ b/configs/airline_static_v1/run.yaml
@@ -2,6 +2,7 @@ exp: airline_static_v1
 mode: SHIM            # REAL | SHIM (SHIM for fast, offline)
 trials: 3             # smaller than escalating for quick demo
 seeds: [11, 12]       # two seeds for variance check
+policy: benign        # risk tag for policy gate (benign|sensitive|prohibited)
 
 attack:
   name: static_dialogue_v1

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -615,6 +615,15 @@ def main() -> None:
     summary_path = base_dir / "summary.csv"
 
     jsonl_files = sorted(base_dir.rglob("*.jsonl"))
+    if not jsonl_files:
+        legacy_root = base_dir.parent
+        legacy_candidates: List[Path] = []
+        for path in legacy_root.rglob("*.jsonl"):
+            try:
+                path.relative_to(base_dir)
+            except ValueError:
+                legacy_candidates.append(path)
+        jsonl_files = sorted(legacy_candidates)
     new_rows: List[Dict[str, str]] = []
     for path in jsonl_files:
         try:

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import random
+import subprocess
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -136,6 +138,55 @@ def main() -> None:
         raise SystemExit("Config missing 'exp' field")
 
     config_path = Path(args.config)
+    requested_mode = str(cfg.get("mode", "SHIM")).upper()
+
+    gate_decision: Dict[str, Any] = {
+        "requested_mode": requested_mode,
+        "effective_mode": requested_mode,
+        "allowed": True,
+        "tag": "unknown",
+        "reason": "",
+    }
+
+    gate_script = Path(__file__).resolve().parents[1] / "tools" / "policy_gate.py"
+    if gate_script.exists():
+        env = os.environ.copy()
+        env["MODE"] = requested_mode
+        try:
+            raw = subprocess.check_output(
+                [sys.executable, gate_script.as_posix(), config_path.as_posix()],
+                text=True,
+                env=env,
+            ).strip()
+            if raw:
+                gate_decision = json.loads(raw)
+        except Exception:
+            gate_decision = {
+                "requested_mode": requested_mode,
+                "effective_mode": requested_mode,
+                "allowed": True,
+                "tag": "unknown",
+                "reason": "gate-unavailable",
+            }
+    else:
+        gate_decision["reason"] = "gate-missing"
+
+    effective_mode = str(gate_decision.get("effective_mode", requested_mode) or "SHIM").upper()
+    gate_decision["effective_mode"] = effective_mode
+    gate_decision["requested_mode"] = str(
+        gate_decision.get("requested_mode", requested_mode) or requested_mode
+    ).upper()
+    tag_value = gate_decision.get("tag")
+    if not tag_value or tag_value == "unknown":
+        gate_decision["tag"] = str(
+            cfg.get("policy") or cfg.get("policy_tag") or "benign"
+        ).strip().lower()
+
+    if requested_mode == "REAL" and effective_mode != "REAL":
+        print(f"[policy] rerouting REAL -> {effective_mode}: {gate_decision.get('reason', '')}")
+
+    cfg["mode"] = effective_mode
+    requested_mode = effective_mode
     cfg_hash_value = cfg_hash(config_path)
     config_parent = config_path.parent.name or config_path.stem
     short_hash = cfg_hash_value[:8] if cfg_hash_value else "unknown"
@@ -150,7 +201,6 @@ def main() -> None:
             raise SystemExit("Seed must be provided via --seed or config 'seeds'")
     seed = int(seed)
 
-    requested_mode = str(cfg.get("mode", "SHIM")).upper()
     trials = int(cfg.get("trials", 0))
 
     outdir = Path(args.outdir).expanduser()
@@ -230,6 +280,17 @@ def main() -> None:
         mode=actual_mode,
         meta_path=jsonl_path.with_suffix(".meta.json"),
     )
+
+    run_json_path = outdir / "run.json"
+    outdir.mkdir(parents=True, exist_ok=True)
+    try:
+        run_meta = json.loads(run_json_path.read_text(encoding="utf-8"))
+    except Exception:
+        run_meta = {}
+    run_meta.setdefault("results_schema", "1")
+    run_meta["mode"] = actual_mode
+    run_meta["policy"] = gate_decision
+    run_json_path.write_text(json.dumps(run_meta, indent=2), encoding="utf-8")
 
     print(f"ASR={asr:.6f}")
     print(f"JSONL={jsonl_path.as_posix()}")

--- a/tools/apply_schema_v1.py
+++ b/tools/apply_schema_v1.py
@@ -51,14 +51,23 @@ def ensure_schema_column(csv_path: Path) -> None:
     tmp.replace(csv_path)
 
 def write_run_json(run_dir: Path) -> None:
-    out = {
-        "results_schema": SCHEMA_VERSION,
-        "summary_schema": SCHEMA_VERSION,
-        "run_id": run_dir.name,
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "git": git_info(),
-    }
-    (run_dir / "run.json").write_text(json.dumps(out, indent=2), encoding="utf-8")
+    run_json = run_dir / "run.json"
+    try:
+        existing = json.loads(run_json.read_text(encoding="utf-8"))
+    except Exception:
+        existing = {}
+
+    existing.update(
+        {
+            "results_schema": SCHEMA_VERSION,
+            "summary_schema": SCHEMA_VERSION,
+            "run_id": run_dir.name,
+            "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "git": git_info(),
+        }
+    )
+
+    run_json.write_text(json.dumps(existing, indent=2), encoding="utf-8")
 
 def main(argv):
     if len(argv) < 2 or argv[1] in ("-h", "--help"):

--- a/tools/policy_gate.py
+++ b/tools/policy_gate.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def load_config(path: str | os.PathLike[str]) -> dict:
+    with open(path, "r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def decide(tag: str, requested_mode: str, allow_sensitive: bool) -> dict:
+    tag_normalized = (tag or "benign").strip().lower()
+    requested = (requested_mode or "SHIM").strip().upper()
+    decision = {
+        "requested_mode": requested,
+        "tag": tag_normalized,
+        "allowed": True,
+        "effective_mode": requested,
+        "reason": "",
+    }
+    if requested != "REAL":
+        return decision
+    if tag_normalized == "benign":
+        return decision
+    if tag_normalized == "sensitive" and not allow_sensitive:
+        decision.update(
+            {
+                "allowed": False,
+                "effective_mode": "SHIM",
+                "reason": "policy: sensitive routed to SHIM (no override)",
+            }
+        )
+        return decision
+    if tag_normalized == "prohibited":
+        decision.update(
+            {
+                "allowed": False,
+                "effective_mode": "SHIM",
+                "reason": "policy: prohibited content never sent to REAL",
+            }
+        )
+        return decision
+    return decision
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv
+    if len(args) < 2:
+        print(json.dumps({"error": "usage: policy_gate.py <CONFIG>"}))
+        return 2
+
+    cfg_path = Path(args[1]).expanduser().resolve()
+    requested_mode = os.environ.get("MODE", "SHIM")
+    allow_sensitive = os.environ.get("ALLOW_SENSITIVE", "0") == "1"
+
+    cfg = load_config(cfg_path)
+    tag = cfg.get("policy") or cfg.get("policy_tag") or "benign"
+
+    decision = decide(tag, requested_mode, allow_sensitive)
+    print(json.dumps(decision))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a reusable `tools/policy_gate.py` helper and call it from `scripts/run_experiment.py` to reroute sensitive/prohibited configs away from REAL providers while recording the decision in run.json
- tag the built-in airline configs as `policy: benign`, document the routing rules in the README, and keep existing run.json metadata when schema tooling runs
- extend aggregation to fall back to legacy JSONL locations so existing batch workflows still produce populated summaries

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cde64f9ff08329851d26651e73c7b9