### PR TITLE
Add provider probe utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy to ".env" locally (never commit .env).
+# In CI, use repository Secrets instead.
+GROQ_API_KEY=put_key_here
+GEMINI_API_KEY=put_key_here

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,20 @@ tidy-run: ## Remove redundant files in results/$(RUN_ID) (timestamped copies, PN
 open-artifacts: latest
 	@$(PYTHON) tools/open_artifacts.py --results "$(RESULTS_DIR)/LATEST"
 
+#
+# === Provider probes ===
+.PHONY: probe-groq
+probe-groq: ## Verify Groq connectivity (needs GROQ_API_KEY)
+	@$(PYTHON) tools/llm_probe.py --provider groq --model llama-3.1-8b-instant --prompt "Say: OK"
+
+.PHONY: probe-gemini
+probe-gemini: ## Verify Gemini connectivity (needs GEMINI_API_KEY)
+	@$(PYTHON) tools/llm_probe.py --provider gemini --model gemini-1.5-flash-latest --prompt "Say: OK"
+
+.PHONY: env-example
+env-example: ## Write a local .env from template if missing
+	@[ -f .env ] && echo ".env already exists" || (cp .env.example .env && echo "Wrote .env (fill in keys)")
+
 .PHONY: list-runs
 list-runs: ## List timestamped results/<RUN_ID> folders and whether CSV/SVG exist
 	@if [ ! -d "$(RESULTS_DIR)" ]; then \

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ RUN_ID=$(date -u +%Y%m%d-%H%M%S) make demo report
 
 Prefer one command? Run `make quickstart` for `install → demo → report → open-artifacts`.
 
+### Real model (first step): probe a provider
+Before wiring REAL into experiments, verify your credentials + connectivity:
+1. Copy the template and add your key (local only — never commit `.env`):
+   ```bash
+   cp .env.example .env
+   # fill GROQ_API_KEY=... (or GEMINI_API_KEY=...)
+   ```
+2. Run a probe:
+   ```bash
+   make probe-groq     # or: make probe-gemini
+   ```
+You should see `PROBE: OK` and a short model reply. In CI, set repo **Secrets**
+(e.g., `GROQ_API_KEY`) instead of using `.env`.
+
 ### Latest Results (auto)
 Local runs write the freshest artifacts directly to `results/` (updated by `make report`).
 In CI, the workflow publishes a `results/LATEST/` folder inside the run’s artifacts,

--- a/tools/llm_probe.py
+++ b/tools/llm_probe.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+LLM connectivity probe for REAL providers.
+- Provider: 'groq' (default), 'gemini' (optional)
+- No external deps (uses urllib), small payload, clear errors.
+Usage:
+  python tools/llm_probe.py --provider groq --model llama-3.1-8b-instant --prompt "say OK"
+"""
+from __future__ import annotations
+import argparse, json, os, sys, urllib.request, urllib.error
+from tools.secrets import ensure_loaded
+
+def _http_post(url: str, headers: dict, payload: dict) -> dict:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            return json.loads(raw.decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="ignore")
+        raise RuntimeError(f"HTTP {e.code} {e.reason}: {body}") from None
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Network error: {e}") from None
+
+def probe_groq(model: str, prompt: str) -> dict:
+    key = os.environ.get("GROQ_API_KEY")
+    if not key:
+        raise RuntimeError("Missing GROQ_API_KEY (set in env or .env)")
+    url = "https://api.groq.com/openai/v1/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model or "llama-3.1-8b-instant",
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.0,
+        "max_tokens": 64,
+    }
+    return _http_post(url, headers, payload)
+
+def probe_gemini(model: str, prompt: str) -> dict:
+    key = os.environ.get("GEMINI_API_KEY")
+    if not key:
+        raise RuntimeError("Missing GEMINI_API_KEY (set in env or .env)")
+    model = model or "gemini-1.5-flash-latest"
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
+    headers = {"Content-Type": "application/json"}
+    payload = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {"temperature": 0.0, "maxOutputTokens": 64},
+    }
+    return _http_post(url, headers, payload)
+
+def main() -> int:
+    ensure_loaded()
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--provider", default="groq", choices=["groq", "gemini"])
+    ap.add_argument("--model", default="")
+    ap.add_argument("--prompt", default="Say: OK")
+    args = ap.parse_args()
+
+    try:
+        if args.provider == "groq":
+            out = probe_groq(args.model, args.prompt)
+            # OpenAI-style shape
+            text = (out.get("choices") or [{}])[0].get("message", {}).get("content", "")
+        else:
+            out = probe_gemini(args.model, args.prompt)
+            # Gemini-style shape
+            candidates = out.get("candidates") or [{}]
+            parts = (candidates[0].get("content") or {}).get("parts") or [{}]
+            text = parts[0].get("text", "")
+    except Exception as e:
+        print(f"PROBE: FAIL — {e}", file=sys.stderr)
+        return 1
+
+    print("PROBE: OK")
+    print(text.strip())
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/secrets.py
+++ b/tools/secrets.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Minimal secrets loader: env first, then a local .env if present.
+Avoids non-stdlib deps.
+"""
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Dict
+
+def _parse_dotenv(text: str) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            k, v = line.split("=", 1)
+            out[k.strip()] = v.strip()
+    return out
+
+def ensure_loaded(dotenv_path: str = ".env") -> None:
+    # If vars already set, we don't override.
+    p = Path(dotenv_path)
+    if not p.exists():
+        return
+    try:
+        data = _parse_dotenv(p.read_text(encoding="utf-8"))
+        for k, v in data.items():
+            os.environ.setdefault(k, v)
+    except Exception:
+        # Fail soft; probes will surface missing keys explicitly.
+        pass


### PR DESCRIPTION
## Summary
- add a lightweight secrets loader that reads environment variables or a local .env
- add a dependency-free LLM probe script and Make targets for Groq and Gemini
- document the probe flow in the README and provide an .env example template

## Testing
- python -m compileall tools/secrets.py tools/llm_probe.py

------
https://chatgpt.com/codex/tasks/task_e_68ce833d33c48329b892bbcec3f3e77d