### PR TITLE
Update Groq probe model

### DIFF
--- a/.github/workflows/probe-provider.yml
+++ b/.github/workflows/probe-provider.yml
@@ -23,15 +23,20 @@ jobs:
         if: steps.pick.outputs.prov == 'groq'
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          # Optional: override in workflow run -> 'Env vars' as GROQ_MODEL
+          # Examples: llama-3.1-70b-versatile, llama-3.1-8b-instant, llama-guard-3-8b
+          GROQ_MODEL: ${{ env.GROQ_MODEL }}
         run: |
           set -euo pipefail
 
           if [ -z "$GROQ_API_KEY" ]; then
             echo "Missing GROQ_API_KEY secret"; exit 1
           fi
+          # Default to a currently-supported model if none provided
+          MODEL="${GROQ_MODEL:-llama-3.1-70b-versatile}"
           # Minimal chat prompt using Groq's OpenAI-compatible endpoint
           BODY='{
-            "model": "mixtral-8x7b-32768",
+            "model": "'"${MODEL}"'",
             "messages": [{"role":"user","content":"Reply with: GROQ_OK"}],
             "temperature": 0
           }'


### PR DESCRIPTION
## Summary
- allow overriding the Groq probe model via a GROQ_MODEL env var
- default the probe to llama-3.1-70b-versatile to use a currently supported model

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68ce907be680832990a4ad0608f8859e