### PR TITLE
Update Groq probe workflow to use llama-3.1-8b-instant

### DIFF
--- a/.github/workflows/probe-provider.yml
+++ b/.github/workflows/probe-provider.yml
@@ -16,7 +16,7 @@ on:
       groq_model:
         description: "Groq model (OpenAI-compatible)"
         required: false
-        default: "llama-3.1-70b-versatile"
+        default: "llama-3.1-8b-instant"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- update the probe-provider workflow's default Groq model to the supported llama-3.1-8b-instant option

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce94367fdc83299099910441ca360a