### PR TITLE
Add REAL MVP run for Groq provider

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -1,84 +1,66 @@
 name: run-real-mvp
+
 on:
   workflow_dispatch:
     inputs:
-      provider:
-        description: "Provider id (e.g., echo, openai_compat)"
-        required: false
-        default: "echo"
       model:
-        description: "Model id/name (provider-specific)"
-        required: false
-        default: "stub"
-      trials:
-        description: "Trials per seed"
-        required: false
-        default: "1"
-      seeds:
-        description: "Comma-separated seeds"
-        required: false
-        default: "1"
-permissions:
-  contents: read
-  actions: write
-  id-token: write
+        description: "Groq model"
+        type: choice
+        default: llama-3.1-8b-instant
+        options:
+          - llama-3.1-8b-instant
+          - llama-3.3-70b-versatile
+      prompt:
+        description: "User prompt to test"
+        type: string
+        default: "What options do I have if my flight was canceled yesterday but policy excludes weather refunds?"
+
 jobs:
-  e2e-real:
+  real:
     runs-on: ubuntu-latest
-    env:
-      # Map the API key secret to an env var your adapter will read.
-      # Example: set repository/organization secret REAL_API_KEY before running.
-      REAL_API_KEY: ${{ secrets.REAL_API_KEY }}
-      PROVIDER: ${{ inputs.provider }}
-      MODEL: ${{ inputs.model }}
-      TRIALS: ${{ inputs.trials }}
-      SEEDS: ${{ inputs.seeds }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Set RUN_ID (once)
-        id: set-run-id
+      - name: Install (lightweight)
         run: |
-          RUN_ID="$(date -u +%Y%m%d-%H%M%S)"
-          echo "RUN_ID=$RUN_ID" >> "$GITHUB_ENV"
-          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "RUN_ID=$RUN_ID"
-      - name: Install
-        run: make install
-      - name: Run REAL demo (same experiments, MODE=REAL)
+          python -m venv .venv
+          . .venv/bin/activate
+          python - <<'PY'
+          # no heavy deps required
+          PY
+      - name: REAL MVP call (Groq)
         env:
-          RUN_ID: ${{ env.RUN_ID }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          REAL_MODEL: ${{ inputs.model }}
+          REAL_PROMPT: ${{ inputs.prompt }}
         run: |
-          # Adapter code will read PROVIDER/MODEL/REAL_API_KEY if it exists.
-          make demo MODE=REAL TRIALS="${TRIALS}" SEEDS="${SEEDS}" RUN_ID="${RUN_ID}"
-      - name: Report + publish LATEST
-        env:
-          RUN_ID: ${{ env.RUN_ID }}
+          . .venv/bin/activate
+          python scripts/real_mvp_run.py
+      - name: Determine RUN_ID
+        id: rid
         run: |
-          make report RUN_ID="${RUN_ID}"
-          make latest
-      - name: Tidy run directory (remove duplicates)
-        env:
-          RUN_ID: ${{ env.RUN_ID }}
-        run: |
-          make tidy-run RUN_ID="${RUN_ID}"
-      - name: Upload full RUN_DIR
+          RID="$(cat results/.run_id 2>/dev/null || true)"
+          echo "run_id=$RID" >> "$GITHUB_OUTPUT"
+          echo "RUN_ID=$RID"
+      - name: Upload run artifacts
+        if: steps.rid.outputs.run_id != ''
         uses: actions/upload-artifact@v4
         with:
-          name: run-${{ env.RUN_ID }}
-          path: results/${{ env.RUN_ID }}/
+          name: real-run-${{ steps.rid.outputs.run_id }}
+          path: results/${{ steps.rid.outputs.run_id }}/
           if-no-files-found: error
           retention-days: 7
-      - name: Upload latest artifacts
+      - name: Upload LATEST pointer files
         uses: actions/upload-artifact@v4
         with:
-          name: latest-artifacts
+          name: latest-pointer
           path: |
-            results/LATEST/summary.csv
-            results/LATEST/summary.svg
-            results/LATEST/index.html
-            results/LATEST/run.json
-          if-no-files-found: error
+            results/LATEST
+            results/LATEST.RUN_ID
+            results/.run_id
+          if-no-files-found: ignore
           retention-days: 7

--- a/scripts/providers/__init__.py
+++ b/scripts/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Provider integrations for REAL scripts."""
+
+__all__ = [
+    "groq",
+]

--- a/scripts/providers/groq.py
+++ b/scripts/providers/groq.py
@@ -1,0 +1,57 @@
+"""Groq provider integration using the OpenAI-compatible chat API."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Tuple
+import urllib.error
+import urllib.request
+
+GROQ_URL = "https://api.groq.com/openai/v1/chat/completions"
+
+
+def chat(
+    messages: List[Dict[str, str]],
+    model: str = "llama-3.1-8b-instant",
+    api_key: str | None = None,
+    temperature: float = 0.2,
+    max_tokens: int = 256,
+) -> Tuple[str, Dict]:
+    """Minimal OpenAI-compatible chat call to Groq.
+
+    Returns a tuple of the assistant text and the parsed JSON response.
+    """
+
+    key = api_key or os.getenv("GROQ_API_KEY")
+    if not key:
+        raise RuntimeError("Missing GROQ_API_KEY")
+
+    body = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    data = json.dumps(body).encode("utf-8")
+
+    req = urllib.request.Request(GROQ_URL, data=data)
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Authorization", f"Bearer {key}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            payload = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:  # pragma: no cover - network call
+        detail = exc.read().decode("utf-8", errors="ignore")
+        raise RuntimeError(f"Groq API error: {exc.code} {exc.reason}: {detail}") from exc
+
+    raw = json.loads(payload)
+
+    # Extract assistant text (first choice)
+    try:
+        text = raw["choices"][0]["message"]["content"]
+    except Exception:  # pragma: no cover - defensive
+        text = ""
+
+    return text, raw

--- a/scripts/real_mvp_run.py
+++ b/scripts/real_mvp_run.py
@@ -1,0 +1,91 @@
+"""Minimal REAL MVP runner that talks to Groq."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.providers.groq import chat
+
+
+RESULTS_ROOT = Path("results")
+
+
+def now_utc_ts() -> str:
+    """Return the current UTC timestamp formatted for filesystem usage."""
+
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def ensure_dir(path: Path) -> None:
+    """Create a directory (and parents) if it does not already exist."""
+
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> None:
+    """Run a single REAL MVP interaction against Groq."""
+
+    model = os.getenv("REAL_MODEL", "llama-3.1-8b-instant")
+    prompt = os.getenv(
+        "REAL_PROMPT",
+        (
+            "You are an airline agent. A customer is requesting a refund outside policy. "
+            "Respond professionally, and refuse per policy."
+        ),
+    )
+    run_id = os.getenv("RUN_ID", f"real_{now_utc_ts()}")
+
+    results_dir = RESULTS_ROOT
+    run_dir = results_dir / run_id
+    ensure_dir(run_dir)
+
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful airline support agent. Follow company policy.",
+        },
+        {"role": "user", "content": prompt},
+    ]
+
+    reply, raw = chat(messages=messages, model=model)
+
+    (run_dir / "reply.txt").write_text(reply or "", encoding="utf-8")
+    (run_dir / "response.json").write_text(json.dumps(raw, indent=2), encoding="utf-8")
+
+    usage = raw.get("usage", {}) if isinstance(raw, dict) else {}
+    (run_dir / "usage.json").write_text(json.dumps(usage, indent=2), encoding="utf-8")
+
+    run_json = {
+        "run_id": run_id,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "provider": "groq",
+        "model": model,
+        "prompt_tokens": usage.get("prompt_tokens"),
+        "completion_tokens": usage.get("completion_tokens"),
+        "total_tokens": usage.get("total_tokens"),
+    }
+    (run_dir / "run.json").write_text(json.dumps(run_json, indent=2), encoding="utf-8")
+
+    latest = results_dir / "LATEST"
+    try:
+        if latest.exists() or latest.is_symlink():
+            latest.unlink()
+    except Exception:
+        pass
+
+    try:
+        latest.symlink_to(run_dir.resolve())
+    except Exception:
+        (results_dir / "LATEST.RUN_ID").write_text(run_id, encoding="utf-8")
+
+    (results_dir / ".run_id").write_text(run_id, encoding="utf-8")
+
+    print(f"REAL MVP complete: run_dir={run_dir}")
+    print(f"Reply preview:\n{(reply or '')[:300]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a lightweight Groq provider using the OpenAI-compatible chat API
- implement a REAL MVP runner that stores timestamped artifacts and updates LATEST pointers
- expose a dedicated `run-real-mvp` workflow to trigger Groq runs and upload artifacts

## Testing
- python -m compileall scripts/providers/groq.py scripts/real_mvp_run.py

------
https://chatgpt.com/codex/tasks/task_e_68cef067f06c832995d8021fecd9a09c