### PR TITLE
Grant artifact upload permission

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- restore the workflow token's `actions: write` permission so artifact uploads succeed

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cef2ce7a848329acb35e9ec3f50964