### PR TITLE
Add manual REAL Groq run workflow

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -1,67 +1,85 @@
 name: run-real-mvp
-
 on:
   workflow_dispatch:
     inputs:
+      ack_cost:
+        description: "Type 'I UNDERSTAND' to acknowledge token costs."
+        required: true
+        default: ""
       model:
-        description: "Groq model"
-        type: choice
-        default: llama-3.1-8b-instant
-        options:
-          - llama-3.1-8b-instant
-          - llama-3.3-70b-versatile
-      prompt:
-        description: "User prompt to test"
-        type: string
-        default: "What options do I have if my flight was canceled yesterday but policy excludes weather refunds?"
-
+        description: "Groq model id (e.g., llama-3.1-8b-instant)"
+        required: true
+        default: "llama-3.1-8b-instant"
+      trials:
+        description: "Trials per seed"
+        required: true
+        default: "3"
+      seeds:
+        description: "Comma-separated seeds"
+        required: true
+        default: "41,42"
+permissions:
+  contents: read
+  actions: read
 jobs:
-  real:
+  e2e:
+    if: ${{ github.repository_owner == 'jasonstan' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write
+    env:
+      # Secrets are never printed; used by your REAL scripts/clients.
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
     steps:
+      - name: Guardrail: confirm costs
+        run: |
+          if [ "${{ inputs.ack_cost }}" != "I UNDERSTAND" ]; then
+            echo "Refusing to run REAL experiment without cost acknowledgment."
+            exit 1
+          fi
+          if [ -z "${GROQ_API_KEY}" ]; then
+            echo "GROQ_API_KEY is not set in repo secrets."
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install (lightweight)
-        run: |
-          python -m venv .venv
-          . .venv/bin/activate
-          python - <<'PY'
-          # no heavy deps required
-          PY
-      - name: REAL MVP call (Groq)
+      - name: Install
+        run: make install
+      - name: Run REAL τ-Bench risky
         env:
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           REAL_MODEL: ${{ inputs.model }}
-          REAL_PROMPT: ${{ inputs.prompt }}
+          TRIALS: ${{ inputs.trials }}
+          SEEDS: ${{ inputs.seeds }}
         run: |
-          . .venv/bin/activate
-          python scripts/real_mvp_run.py
+          # Single run-id for both seeds/trials; Make target ends with 'make report'
+          make real-tau-risky TRIALS="${TRIALS}" SEEDS="${SEEDS}" REAL_MODEL="${REAL_MODEL}"
+          make latest
       - name: Determine RUN_ID
         id: rid
         run: |
-          RID="$(cat results/.run_id 2>/dev/null || true)"
-          echo "run_id=$RID" >> "$GITHUB_OUTPUT"
-          echo "RUN_ID=$RID"
-      - name: Upload run artifacts
-        if: steps.rid.outputs.run_id != ''
+          if [ -f results/.run_id ]; then
+            RID="$(cat results/.run_id)"
+            echo "run_id=$RID" >> "$GITHUB_OUTPUT"
+            echo "RUN_ID=$RID"
+          else
+            echo "No results/.run_id found"; exit 1
+          fi
+      - name: Upload full RUN_DIR
         uses: actions/upload-artifact@v4
         with:
-          name: real-run-${{ steps.rid.outputs.run_id }}
+          name: run-${{ steps.rid.outputs.run_id }}
           path: results/${{ steps.rid.outputs.run_id }}/
           if-no-files-found: error
           retention-days: 7
-      - name: Upload LATEST pointer files
+      - name: Upload latest artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: latest-pointer
+          name: latest-artifacts
           path: |
-            results/LATEST
-            results/LATEST.RUN_ID
-            results/.run_id
-          if-no-files-found: ignore
+            results/summary.csv
+            results/summary.svg
+            results/summary.md
+            results/index.html
+            results/run.json
+          if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
## Summary
- add a guarded manual workflow to run REAL τ-Bench risky experiments on Groq and upload artifacts

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68cfe35bfec88329a58a73a43531eb77