### PR TITLE
Fix REAL Groq workflow artifact permissions and run id handling

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -20,7 +20,7 @@ on:
         default: "41,42"
 permissions:
   contents: read
-  actions: read
+  actions: write
 jobs:
   e2e:
     if: ${{ github.repository_owner == 'jasonstan' }}
@@ -52,8 +52,12 @@ jobs:
           SEEDS: ${{ inputs.seeds }}
         run: |
           # Single run-id for both seeds/trials; Make target ends with 'make report'
-          make real-tau-risky TRIALS="${TRIALS}" SEEDS="${SEEDS}" REAL_MODEL="${REAL_MODEL}"
-          make latest
+          RUN_ID="$(date -u "+%Y%m%d-%H%M%S")"
+          export RUN_ID
+          make real-tau-risky RUN_ID="${RUN_ID}" TRIALS="${TRIALS}" SEEDS="${SEEDS}" REAL_MODEL="${REAL_MODEL}"
+          make latest RUN_ID="${RUN_ID}"
+          mkdir -p results
+          printf '%s\n' "${RUN_ID}" > results/.run_id
       - name: Determine RUN_ID
         id: rid
         run: |


### PR DESCRIPTION
## Summary
- restore workflow permissions so artifact uploads can succeed
- persist the generated run id after invoking the REAL τ-Bench risky target so guard steps succeed

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cfe5ef761c83299443c1fe473ebe3c