### PR TITLE
Resolve conflicts for guard contract update

### DIFF
--- a/policies/gates.py
+++ b/policies/gates.py
@@ -17,13 +17,18 @@ Returned mapping keys:
   ``pre_denied``   – only for pre guards; ``True`` when the guard blocks.
   ``post_denied``  – only for post guards; ``True`` when the guard blocks.
   ``post_pii_hit`` – only for post guards; ``True`` if PII was detected.
+
+Current ``benign`` heuristics denylist obvious risky intents before a call and
+flag simple PII patterns (SSNs, long digit runs) after a call.
 """
 
 from __future__ import annotations
 
+import re
 from typing import TypedDict
 
 DEFAULT_POLICY = "benign"
+
 
 class GuardResult(TypedDict, total=False):
     allowed: bool
@@ -33,6 +38,15 @@ class GuardResult(TypedDict, total=False):
     pre_denied: bool
     post_denied: bool
     post_pii_hit: bool
+
+
+_DENYLIST_KEYWORDS = (
+    "exfiltrate",
+    "leak all",
+    "dump all",
+)
+
+_PII_REGEX = re.compile(r"(\b\d{3}[- ]?\d{2}[- ]?\d{4}\b|\b\d{13,19}\b)", re.IGNORECASE)
 
 
 def _result(*, stage: str, policy: str, allowed: bool, reason: str, post_pii_hit: bool = False) -> GuardResult:
@@ -53,18 +67,51 @@ def _result(*, stage: str, policy: str, allowed: bool, reason: str, post_pii_hit
 def _always_allow(_: str, *, stage: str, policy: str) -> GuardResult:
     return _result(stage=stage, policy=policy, allowed=True, reason=f"{stage}: {policy} — allow")
 
+
+def _has_denylist_keyword(text: str) -> bool:
+    lowered = (text or "").lower()
+    return any(keyword in lowered for keyword in _DENYLIST_KEYWORDS)
+
+
+def _pre_benign_guard(text: str, *, stage: str, policy: str) -> GuardResult:
+    denied = _has_denylist_keyword(text)
+    reason = "denylist_intent" if denied else f"{stage}: {policy} — allow"
+    return _result(stage=stage, policy=policy, allowed=not denied, reason=reason)
+
+
+def _contains_pii(text: str) -> bool:
+    return bool(_PII_REGEX.search(text or ""))
+
+
+def _post_benign_guard(text: str, *, stage: str, policy: str) -> GuardResult:
+    pii_hit = _contains_pii(text)
+    reason = "pii_detected" if pii_hit else f"{stage}: {policy} — allow"
+    return _result(
+        stage=stage,
+        policy=policy,
+        allowed=not pii_hit,
+        reason=reason,
+        post_pii_hit=pii_hit,
+    )
+
+
 # Hook points for future rules (regexes, matchers, policy files, etc.)
 _PRE_DISPATCH = {
-    "benign": _always_allow,
+    "benign": _pre_benign_guard,
 }
+_PRE_DISPATCH_DEFAULT = _always_allow
+
 _POST_DISPATCH = {
-    "benign": _always_allow,
+    "benign": _post_benign_guard,
 }
+_POST_DISPATCH_DEFAULT = _always_allow
+
 
 def pre_call_guard(text: str, *, policy: str = DEFAULT_POLICY) -> GuardResult:
-    handler = _PRE_DISPATCH.get(policy, _always_allow)
+    handler = _PRE_DISPATCH.get(policy, _PRE_DISPATCH_DEFAULT)
     return handler(text, stage="pre", policy=policy)
 
+
 def post_call_guard(text: str, *, policy: str = DEFAULT_POLICY) -> GuardResult:
-    handler = _POST_DISPATCH.get(policy, _always_allow)
+    handler = _POST_DISPATCH.get(policy, _POST_DISPATCH_DEFAULT)
     return handler(text, stage="post", policy=policy)


### PR DESCRIPTION
## Summary
- preserve the GuardResult mapping contract while integrating the latest benign denylist and PII heuristics
- document the current benign policy behaviour and keep explicit fallbacks for unknown policies

## Testing
- pytest tests/test_lib.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d05d086e34832984601599298bc885