### PR TITLE
Fix REAL MVP workflow

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -50,6 +50,7 @@ jobs:
 
           # Single RUN_ID for the whole session
           RUN_ID="$(date -u '+%Y%m%d-%H%M%S')"
+          export RUN_ID
           echo "$RUN_ID" > results/.run_id
           echo "RUN_ID=$RUN_ID" >> "$GITHUB_ENV"
           echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- resolve the REAL MVP workflow conflict and restore the actions: write permission needed for artifact uploads
- generate a single RUN_ID per session, persist it for later steps, and fail fast when report assets are missing
- export RUN_ID before invoking make so all stages operate on the same run directory
- publish both per-run and latest artifact bundles with strict shell execution and required outputs

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d07138ff9c832981ebe46260d93aea