### PR TITLE
Fix conflict marker workflow exit reliability

### DIFF
--- a/.github/workflows/no-conflict-markers.yml
+++ b/.github/workflows/no-conflict-markers.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Scanning tracked files for Git conflict markers..."
-          if git ls-files -z | xargs -0 grep -nE '^(<{7}|={7}|>{7})' --color=never -H; then
+          if git grep -nE '^(<{7}|={7}|>{7})' --color=never; then
             echo "::error title=Conflict markers detected::Resolve all <<<<<<< ======= >>>>>>> sections before merging."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- replace the xargs + grep conflict scan with git grep to avoid 123 exit codes masking failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d12cef703083298f4d605b57443781