### PR TITLE
deps: add PyYAML to CI/runtime so YAML tests run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ venv: ## Create local virtualenv in .venv
 	$(PY) -m pip install -U pip
 
 install: venv ## Install runtime + dev deps into .venv
-	$(PIP) install -U doomarena doomarena-taubench pytest pyyaml pandas matplotlib
+	$(PIP) install -U doomarena doomarena-taubench pytest PyYAML==6.0.2 pandas matplotlib
 	$(PY) scripts/ensure_tau_bench.py || (echo "tau_bench unavailable; continuing without real τ-Bench" && exit 0)
 
 check-schema: venv

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ make open-report                     # opens results/LATEST/index.html
 # Real provider calls: set DRY_RUN=0 in .env or run `DRY_RUN=0 make mvp`
 ```
 
+The CLI and governance tooling rely on YAML configs and policies, so the setup instructions pin
+`PyYAML==6.0.2`. Install via the requirements files above if you manage environments manually.
+
 ## Why this exists
 - Enable **fast iteration** with **CI-friendly artifacts** you can attach to PRs.
 - Provide **SHIM** simulation adapters for deterministic demos and a **REAL** path to cloud models.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,7 +1,7 @@
 doomarena
 doomarena-taubench
 pytest
-pyyaml
+PyYAML==6.0.2
 requests>=2.31,<3.0
 numpy>=1.26.4,<2.0
 pandas>=2.2.2,<2.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Dev/test deps (keep light; match Makefile install)
 pytest
-pyyaml
+PyYAML==6.0.2
 requests>=2.31,<3.0
 numpy>=1.26.4,<2.0
 pandas>=2.2.2,<2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Runtime dependencies for DoomArena-Lab CLI/tools.
+PyYAML==6.0.2


### PR DESCRIPTION
## Summary
- pin PyYAML==6.0.2 across CI, dev, and runtime install paths
- document the pinned YAML dependency in the quickstart instructions

## Testing
- pip install -r requirements-ci.txt
- pytest tests/test_stream_aggregate.py
- make mvp

------
https://chatgpt.com/codex/tasks/task_e_68d3c32d610c8329b649da66a192153c