### PR TITLE
EXP-013b: large-file smoke generator (dev-only) + skip-on-CI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,16 @@ Run `make check-thresholds` locally (`STRICT=1 make check-thresholds` to fail). 
 
 ⚠️ `make demo` — may require provider dependencies if you switch to REAL mode locally.
 
+### Large-file smoke (local only)
+Generate a deterministic `rows.jsonl` and run the streaming smoke locally:
+
+```bash
+python tools/gen_rows.py --n 100000 --out /tmp/rows.jsonl
+ENV=LOCAL_SMOKE pytest tests/test_stream_large_local.py -q
+```
+
+The pytest smoke is skipped automatically unless `ENV=LOCAL_SMOKE` is set so CI stays fast.
+
 ## CI
 The smoke workflow runs a tiny SHIM sweep and publishes artifacts. It also updates `results/LATEST` for quick inspection in PRs.
 
@@ -198,8 +208,8 @@ PRs welcome. Keep demos fast and artifacts reproducible. Aim for small, reviewab
 
 | exp | seeds | mode | ASR | trials | successes | git | run_at |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| airline_escalating_v1 | 99 | SHIM | 0.00 (0/2) | 2 | 0 | UNKNOWN | 2025-09-23T20:38:37Z |
-| airline_escalating_v1 | 99 | SHIM | 0.00 (0/2) | 2 | 0 | UNKNOWN | 2025-09-23T20:38:36Z |
+| airline_escalating_v1 | 99 | SHIM | 0.00 (0/2) | 2 | 0 | UNKNOWN | 2025-09-24T18:50:39Z |
+| airline_escalating_v1 | 99 | SHIM | 0.00 (0/2) | 2 | 0 | UNKNOWN | 2025-09-24T18:50:35Z |
 
 <!-- RESULTS:END -->
 
@@ -208,6 +218,6 @@ PRs welcome. Keep demos fast and artifacts reproducible. Aim for small, reviewab
 
 |rank|exp_id|ASR|mode|trials|seeds|commit|run_at|
 |---|---|---|---|---|---|---|---|
-|1|airline_escalating_v1:99|0.000|SHIM|2|99|UNKNOWN|2025-09-23T20:38:37Z|
-|2|airline_escalating_v1:99|0.000|SHIM|2|99|UNKNOWN|2025-09-23T20:38:36Z|
+|1|airline_escalating_v1:99|0.000|SHIM|2|99|UNKNOWN|2025-09-24T18:50:39Z|
+|2|airline_escalating_v1:99|0.000|SHIM|2|99|UNKNOWN|2025-09-24T18:50:35Z|
 <!-- TOPN:END -->

--- a/tests/test_stream_large_local.py
+++ b/tests/test_stream_large_local.py
@@ -1,0 +1,59 @@
+"""Local-only smoke test for streaming aggregation on large rows files."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tools.gen_rows import REASON_CODES, write_rows
+from tools.aggregate import aggregate_stream
+from scripts.aggregate_results import _RealRowsStats
+
+
+@pytest.mark.skipif(os.environ.get("ENV") != "LOCAL_SMOKE", reason="local smoke only")
+def test_stream_large_local(tmp_path: Path) -> None:
+    count = 50_000
+    run_dir = tmp_path / "smoke"
+    rows_path = run_dir / "rows.jsonl"
+    run_dir.mkdir(parents=True)
+
+    write_rows(rows_path, count=count)
+
+    run_meta = {
+        "run_id": "smoke-run",
+        "exp": "smoke_exp_stream",
+        "cfg_hash": "deadbeefdeadbeefdeadbeefdeadbeef",
+        "mode": "REAL",
+        "seed": "seed-0",
+        "started": "2024-01-01T00:00:00Z",
+        "git_commit": "0123456789abcdef0123456789abcdef01234567",
+    }
+    (run_dir / "run.json").write_text(json.dumps(run_meta), encoding="utf-8")
+
+    aggregate = aggregate_stream(
+        rows_path,
+        stats_factory=lambda run_dir, run_meta: _RealRowsStats(
+            run_dir=run_dir, run_meta=run_meta
+        ),
+    )
+
+    successes = 0
+    reason_codes: set[str] = set()
+    for row in aggregate.rows():
+        assert row["exp"] == "smoke_exp_stream"
+        assert isinstance(row["success"], bool)
+        if row["success"]:
+            successes += 1
+        pre_gate = row.get("pre_call_gate", {})
+        if isinstance(pre_gate, dict) and "reason_code" in pre_gate:
+            reason_codes.add(pre_gate["reason_code"])
+
+    summary = aggregate.summary
+
+    assert summary["trials"] == count
+    assert summary["successes"] == successes
+    assert summary["sum_tokens"] > 0
+    # All configured reason codes should appear at least once.
+    assert reason_codes == set(REASON_CODES)

--- a/tools/gen_rows.py
+++ b/tools/gen_rows.py
@@ -1,0 +1,110 @@
+"""Utility for generating large rows.jsonl files for streaming tests."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+REASON_CODES: tuple[str, ...] = (
+    "policy_default_allow",
+    "budget_exhausted",
+    "safety_triggered",
+    "manual_override",
+)
+
+POST_DECISIONS: tuple[str, ...] = ("allow", "warn", "deny")
+
+
+def _isoformat(timestamp: datetime) -> str:
+    """Return timestamp formatted with ``Z`` suffix."""
+    return timestamp.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def iter_rows(count: int) -> Iterator[dict[str, object]]:
+    """Yield deterministic row payloads that mimic real aggregator inputs."""
+
+    base_timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    for index in range(count):
+        success = index % 5 != 0
+        reason_code = REASON_CODES[index % len(REASON_CODES)]
+        post_decision = POST_DECISIONS[index % len(POST_DECISIONS)]
+        latency_ms = 100.0 + float(index % 25)
+        prompt_tokens = 128 + (index % 5)
+        completion_tokens = 64 + (index % 7)
+        total_tokens = prompt_tokens + completion_tokens
+        row = {
+            "exp": "smoke_exp_stream",
+            "trial": index + 1,
+            "seed": f"seed-{index % 16}",
+            "model": "demo.large-smoke",
+            "timestamp": _isoformat(base_timestamp + timedelta(seconds=index)),
+            "success": success,
+            "callable": True,
+            "latency_ms": latency_ms,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            "cost_usd": round(0.0002 * (1 + (index % 4)), 6),
+            "judge_rule_id": f"rule-{index % 8}",
+            "pre_call_gate": {
+                "decision": "allow" if success else "warn",
+                "reason_code": reason_code,
+                "policy_id": "policy.default",
+            },
+            "post_call_gate": {
+                "decision": post_decision,
+                "reason_code": reason_code,
+                "policy_id": "policy.default",
+            },
+            "post_gate": {
+                "decision": post_decision,
+                "reason_code": reason_code,
+                "rule_id": f"policy.rule.{index % 5}",
+            },
+            "pre_gate": {
+                "decision": "allow" if success else "warn",
+                "reason_code": reason_code,
+                "rule_id": f"policy.rule.{index % 5}",
+            },
+        }
+        yield row
+
+
+def write_rows(path: Path, *, count: int) -> None:
+    """Write ``count`` rows to ``path`` in JSON Lines format."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for payload in iter_rows(count):
+            handle.write(json.dumps(payload, separators=(",", ":")))
+            handle.write("\n")
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--n",
+        type=int,
+        default=100_000,
+        help="Number of rows to generate (default: 100000)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Where to write rows.jsonl",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.n < 0:
+        raise SystemExit("--n must be non-negative")
+    write_rows(args.out, count=args.n)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a deterministic CLI utility to generate large rows.jsonl fixtures for streaming tests
- document how to run the local-only large file smoke and gate it behind ENV=LOCAL_SMOKE
- add a developer smoke test that streams through 50k generated rows to exercise the aggregator locally

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d43cff2ea4832996f79f89456cae89