### PR TITLE
fix: detect latest run via LATEST pointer

### DIFF
--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -56,7 +56,16 @@ jobs:
       - name: Locate latest run dir
         id: findrun
         run: |
-          RUN_DIR=$(ls -1d results/*Z | tail -1)
+          set -euo pipefail
+          python tools/latest_run.py
+          if [ -L results/LATEST ]; then
+            RUN_DIR=$(readlink -f results/LATEST)
+          elif [ -f results/LATEST.path ]; then
+            RUN_DIR=$(cat results/LATEST.path)
+          else
+            echo "Could not determine latest run directory" >&2
+            exit 1
+          fi
           echo "RUN_DIR=$RUN_DIR"
           echo "RUN_DIR=$RUN_DIR" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
- call `tools/latest_run.py` to refresh the LATEST pointer
- resolve the latest run directory via the LATEST link or pointer file instead of assuming a `*Z` suffix

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d52612173c8329b4a276823fd14309