### PR TITLE
fix(report): ensure index fallback and CI regen

### DIFF
--- a/.github/workflows/run-real-mvp.yml
+++ b/.github/workflows/run-real-mvp.yml
@@ -191,6 +191,18 @@ jobs:
           make report RUN_ID="${RUN_ID}"
           make latest
 
+      - name: Ensure index.html exists (fallback render)
+        env:
+          RUN_ID: ${{ env.RUN_ID }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+          RUN_DIR="results/${RUN_ID}"
+          [ -d "$RUN_DIR" ] || (echo "Run dir not found: $RUN_DIR" >&2; exit 1)
+          if [ ! -s "$RUN_DIR/index.html" ]; then
+            python tools/mk_report.py "$RUN_DIR" || true
+          fi
+
       - name: Verify REAL artifacts
         env:
           RUN_ID: ${{ env.RUN_ID }}

--- a/.github/workflows/run-real-tau-risky.yml
+++ b/.github/workflows/run-real-tau-risky.yml
@@ -128,6 +128,17 @@ jobs:
           make report RUN_ID="${RUN_ID}"
           make latest
 
+      - name: Ensure index.html exists (fallback render)
+        env:
+          RUN_ID: ${{ env.RUN_ID }}
+        run: |
+          set -euxo pipefail
+          RUN_DIR="results/${RUN_ID}"
+          [ -d "$RUN_DIR" ] || (echo "Run dir not found: $RUN_DIR" >&2; exit 1)
+          if [ ! -s "$RUN_DIR/index.html" ]; then
+            python tools/mk_report.py "$RUN_DIR" || true
+          fi
+
       - name: Verify REAL artifacts
         env:
           RUN_ID: ${{ env.RUN_ID }}


### PR DESCRIPTION
## Summary
- add summary loading helper and degraded HTML fallback so mk_report always emits an index file
- reuse the existing HTML builder when the optional renderer import is unavailable while capturing degraded output on failures
- teach REAL workflows to regenerate the report if index.html is missing after the report step

## Testing
- python tools/mk_report.py results/test-run

------
https://chatgpt.com/codex/tasks/task_e_68d5e44146bc8329b6aecbab83f21b42