### PR TITLE
Follow-up: restore mk_report helper APIs for downstream tools

### DIFF
--- a/tools/mk_report.py
+++ b/tools/mk_report.py
@@ -1,6 +1,30 @@
 # tools/mk_report.py
+from __future__ import annotations
+
+import csv
+import json
+import sys
 from pathlib import Path
-import sys, json, csv
+
+
+def resolve_run_dir(path: Path) -> Path:
+    """Resolve symlinks and fallback pointer files like results/LATEST.path."""
+
+    resolved = path.resolve(strict=False)
+    if resolved.exists():
+        return resolved
+
+    pointer = path.parent / f"{path.name}.path"
+    if pointer.exists():
+        target = Path(pointer.read_text(encoding="utf-8").strip())
+        if target.exists():
+            try:
+                return target.resolve()
+            except Exception:
+                return target
+
+    return resolved
+
 
 def load_summary(run_dir: Path):
     p_json = run_dir / "summary_index.json"
@@ -9,6 +33,7 @@ def load_summary(run_dir: Path):
             return "json", json.loads(p_json.read_text(encoding="utf-8"))
         except Exception:
             pass
+
     p_csv = run_dir / "summary.csv"
     if p_csv.exists():
         try:
@@ -16,7 +41,9 @@ def load_summary(run_dir: Path):
             return "csv", {"csv_rows": rows}
         except Exception:
             pass
+
     return "none", {}
+
 
 def _degraded_html(run_dir: Path, err: Exception | None = None) -> str:
     msg = f"{type(err).__name__}: {err}" if err else "no data"
@@ -33,29 +60,50 @@ def _degraded_html(run_dir: Path, err: Exception | None = None) -> str:
 </ul>
 """
 
-def main():
-    run_dir = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else None
-    if not run_dir or not run_dir.exists():
-        print("ERROR: mk_report: missing run_dir", file=sys.stderr)
-        sys.exit(2)
+
+def write_report(run_dir: Path) -> None:
+    run_dir = resolve_run_dir(run_dir)
     out_path = run_dir / "index.html"
 
     mode, data = load_summary(run_dir)
 
     try:
-        from tools.report.html_report import render_html  # type: ignore
-    except Exception as e:
-        out_path.write_text(_degraded_html(run_dir, e), encoding="utf-8")
+        from tools.report.html_report import render_html  # type: ignore[attr-defined]
+    except Exception as import_error:
+        html = _degraded_html(run_dir, import_error)
+        out_path.write_text(html, encoding="utf-8")
         print(f"Wrote {out_path} (degraded: import error)")
         return
 
+    degraded = False
     try:
         html = render_html(run_dir, data, mode=mode)
-    except Exception as e:
-        html = _degraded_html(run_dir, e)
+    except Exception as err:
+        html = _degraded_html(run_dir, err)
+        degraded = True
 
     out_path.write_text(html, encoding="utf-8")
-    print(f"Wrote {out_path}")
+    if degraded:
+        print(f"Wrote {out_path} (degraded)")
+    else:
+        print(f"Wrote {out_path}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv if argv is None else argv
+    if len(args) < 2:
+        print("ERROR: mk_report: missing run_dir", file=sys.stderr)
+        return 2
+
+    requested = Path(args[1])
+    run_dir = resolve_run_dir(requested)
+    if not run_dir.exists():
+        print(f"ERROR: mk_report: run_dir does not exist: {requested}", file=sys.stderr)
+        return 2
+
+    write_report(run_dir)
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- reintroduce `resolve_run_dir` and `write_report` helpers in `mk_report` for callers like `open_artifacts` and the HTML renderer
- preserve the resilient, degraded-report fallback behaviour when imports or rendering fail

## Testing
- python -m compileall tools/mk_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d5eef27a3c8329809f630c9f3b858c