### PR TITLE
Restore resolve_run_dir helper in mk_report

### DIFF
--- a/tools/mk_report.py
+++ b/tools/mk_report.py
@@ -1,6 +1,26 @@
 from pathlib import Path
 import sys, json, csv
 
+
+def resolve_run_dir(path: Path) -> Path:
+    """Resolve symlinks and fallback pointer files like results/LATEST.path."""
+
+    resolved = path.resolve(strict=False)
+    if resolved.exists():
+        return resolved
+
+    pointer = path.parent / f"{path.name}.path"
+    if pointer.exists():
+        target = Path(pointer.read_text(encoding="utf-8").strip())
+        if target.exists():
+            try:
+                return target.resolve()
+            except Exception:
+                return target
+
+    return resolved
+
+
 def load_summary(run_dir: Path):
     p_json = run_dir / "summary_index.json"
     if p_json.exists():
@@ -33,10 +53,16 @@ def _degraded_html(run_dir: Path, err: Exception | None = None) -> str:
 """
 
 def main():
-    run_dir = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else None
-    if not run_dir or not run_dir.exists():
+    if len(sys.argv) <= 1:
         print("ERROR: mk_report: missing run_dir", file=sys.stderr)
         sys.exit(2)
+
+    requested = Path(sys.argv[1])
+    run_dir = resolve_run_dir(requested)
+    if not run_dir.exists():
+        print(f"ERROR: mk_report: run_dir does not exist: {requested}", file=sys.stderr)
+        sys.exit(2)
+
     out_path = run_dir / "index.html"
 
     mode, data = load_summary(run_dir)
@@ -50,13 +76,18 @@ def main():
         return
 
     # Attempt full render; fall back to degraded on any error
+    degraded = False
     try:
         html = render_html(run_dir, data, mode=mode)
     except Exception as e:
         html = _degraded_html(run_dir, e)
+        degraded = True
 
     out_path.write_text(html, encoding="utf-8")
-    print(f"Wrote {out_path}")
+    if degraded:
+        print(f"Wrote {out_path} (degraded)")
+    else:
+        print(f"Wrote {out_path}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- restore the resolve_run_dir helper so downstream tools can continue importing it
- update mk_report's CLI path handling to reuse the helper and keep degraded logging parity

## Testing
- python -m compileall tools/mk_report.py tools/report/html_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d5f4e0eef08329af8a8c5c5ec8d23c