### PR TITLE
ci: append artifacts summary via python command

### DIFF
--- a/.github/workflows/demo-guided.yml
+++ b/.github/workflows/demo-guided.yml
@@ -146,14 +146,7 @@ jobs:
           test -s "$RUN_DIR/index.html"
           test -s "$RUN_DIR/summary.csv"
           test -s "$RUN_DIR/summary.svg"
-          {
-            echo "### Artifacts"
-            cat <<EOF
-            - $RUN_DIR/index.html
-            - $RUN_DIR/summary.csv
-            - $RUN_DIR/summary.svg
-            EOF
-          } >> "$GITHUB_STEP_SUMMARY"
+          python -c "import os, pathlib; run_dir = pathlib.Path(os.environ['RUN_DIR']); summary = pathlib.Path(os.environ['GITHUB_STEP_SUMMARY']); lines = ['### Artifacts', *[f'- {run_dir / name}' for name in ('index.html', 'summary.csv', 'summary.svg')]]; text = '\n'.join(lines) + '\n'; summary.parent.mkdir(parents=True, exist_ok=True); summary.touch(exist_ok=True); data = summary.read_text(encoding='utf-8') if summary.stat().st_size else ''; prefix = '\n' if data and not data.endswith('\n') else ''; summary.write_text(f"{data}{prefix}{text}", encoding='utf-8')"
 
       - name: Upload per-run artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- replace the heredoc-based summary append with a Python one-liner to avoid delimiter indentation issues
- ensure the artifact entries are appended as Markdown list items with proper newlines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66a595a58832990849d63d73aaf48