### PR TITLE
ci(guided): set PYTHONPATH for report fallback

### DIFF
--- a/.github/workflows/demo-guided.yml
+++ b/.github/workflows/demo-guided.yml
@@ -155,6 +155,8 @@ jobs:
           echo "RUN_DIR=$RUN_DIR" | tee -a "$GITHUB_ENV"
 
       - name: Ensure report exists (fallback render)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           set -euxo pipefail
           [ -d "$RUN_DIR" ] || (echo "Run dir not found: $RUN_DIR" >&2; exit 1)


### PR DESCRIPTION
## Summary
- set PYTHONPATH to the workspace during the fallback report render

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6727f3ae8832992dc6c8c11f596f2