### PR TITLE
report: discover nested rows/run.json using glob

### DIFF
--- a/tools/mk_report.py
+++ b/tools/mk_report.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import sys, json, csv
+from typing import Optional, Tuple
 
 # --- begin bootstrap so `from tools...` works without PYTHONPATH ---
 here = Path(__file__).resolve()
@@ -43,6 +44,71 @@ def load_summary(run_dir: Path):
             pass
     return "none", {}
 
+
+def _discover_run_and_rows(run_dir: Path) -> Tuple[Optional[Path], Optional[Path]]:
+    """Locate run.json and rows.jsonl, allowing for nested slice folders."""
+
+    # Gather candidates deterministically for reproducibility.
+    run_json_candidates = sorted(run_dir.rglob("run.json"))
+    rows_candidates = sorted(run_dir.rglob("rows.jsonl"))
+
+    selected_run_json: Optional[Path] = None
+    selected_rows: Optional[Path] = None
+
+    if run_json_candidates:
+        # Default to the first path but prefer one whose parent also has rows.jsonl.
+        selected_run_json = run_json_candidates[0]
+        for cand in run_json_candidates:
+            if (cand.parent / "rows.jsonl").exists():
+                selected_run_json = cand
+                break
+
+    if selected_run_json and (selected_run_json.parent / "rows.jsonl").exists():
+        selected_rows = selected_run_json.parent / "rows.jsonl"
+    elif rows_candidates:
+        selected_rows = rows_candidates[0]
+
+    return selected_run_json, selected_rows
+
+
+def _extract_from_run_json(data: dict, run_meta: dict) -> None:
+    """Populate model/seed fields from run.json metadata when missing."""
+
+    def _first_present(keys: Tuple[str, ...]) -> Optional[str]:
+        for key in keys:
+            parts = key.split(".")
+            node: object = run_meta
+            for part in parts:
+                if isinstance(node, dict) and part in node:
+                    node = node[part]
+                else:
+                    node = None
+                    break
+            if node not in (None, ""):
+                return str(node)
+        return None
+
+    # Only override when the current value is missing or "unknown".
+    model = _first_present((
+        "model",
+        "config.model",
+        "real.model",
+        "meta.model",
+    ))
+    current_model = str(data.get("model") or "").strip().lower()
+    if model and (not current_model or current_model == "unknown"):
+        data["model"] = model
+
+    seed = _first_present((
+        "seed",
+        "meta.seed",
+        "config.seed",
+        "params.seed",
+    ))
+    current_seed = str(data.get("seed") or "").strip()
+    if seed and (not current_seed or current_seed == "unknown"):
+        data["seed"] = seed
+
 def _degraded_html(run_dir: Path, err: Exception | None = None) -> str:
     msg = f"{type(err).__name__}: {err}" if err else "no data"
     return f"""<!doctype html><meta charset="utf-8">
@@ -73,13 +139,62 @@ def main():
 
     mode, data = load_summary(run_dir)
 
+    run_json_path, rows_path = _discover_run_and_rows(run_dir)
+    run_meta = {}
+    if run_json_path and run_json_path.exists():
+        try:
+            run_meta = json.loads(run_json_path.read_text(encoding="utf-8"))
+        except Exception:
+            run_meta = {}
+    if run_meta:
+        if mode != "json":
+            # Keep original structure for csv/none modes while surfacing metadata.
+            data = dict(data)
+            if mode == "csv":
+                data.setdefault("csv_rows", [])
+        _extract_from_run_json(data, run_meta)
+
+
     # Import template renderer safely
     try:
-        from tools.report.html_report import render_html  # type: ignore
+        from tools.report import html_report  # type: ignore
     except Exception as e:
         out_path.write_text(_degraded_html(run_dir, e), encoding="utf-8")
         print(f"Wrote {out_path} (degraded: import error)")
         return
+    render_html = html_report.render_html  # type: ignore[attr-defined]
+
+    if rows_path:
+        fallback_rows = rows_path
+
+        def _read_rows_jsonl_override(target_dir: Path, limit: int = 50):
+            candidates = []
+            default = target_dir / "rows.jsonl"
+            if fallback_rows and fallback_rows != default:
+                candidates.append(fallback_rows)
+            candidates.append(default)
+
+            for candidate in candidates:
+                if not candidate or not candidate.exists():
+                    continue
+                out = []
+                try:
+                    with candidate.open(encoding="utf-8") as f:
+                        for i, line in enumerate(f):
+                            if i >= limit:
+                                break
+                            try:
+                                obj = json.loads(line)
+                            except Exception:
+                                continue
+                            out.append(obj)
+                except Exception:
+                    continue
+                if out:
+                    return out
+            return []
+
+        html_report._read_rows_jsonl = _read_rows_jsonl_override  # type: ignore[attr-defined]
 
     # Attempt full render; fall back to degraded on any error
     degraded = False


### PR DESCRIPTION
## Summary
- discover run.json and rows.jsonl via globbing so slice subfolders are detected
- hydrate report metadata from run.json when summary files omit model/seed values
- fall back to nested rows.jsonl when building the trial I/O table

## Testing
- python -m compileall tools/mk_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d676b444e08329a36e67185af260d6