### PR TITLE
fix: correct dry-run flag and restore artifact permissions

### DIFF
--- a/.github/workflows/demo-guided.yml
+++ b/.github/workflows/demo-guided.yml
@@ -30,6 +30,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 # Map inputs to the env used later in the job steps
 env:
@@ -137,7 +138,7 @@ jobs:
     env:
       PYTHONUTF8: "1"
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+      DRY_RUN: ${{ env.DRY_RUN }}
       STREAM: '0'
       GROQ_MODEL: ${{ inputs.model }}
       RISK_TEXT: ${{ inputs.risk_text }}


### PR DESCRIPTION
## Summary
- add actions: write permission back to the workflow so artifacts can upload
- reuse the workflow-scoped DRY_RUN flag when executing to respect the choice input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6897e9c948329b9bed58df8fd4ff6