### PR TITLE
fix: clarify dry run normalization comments

### DIFF
--- a/.github/workflows/demo-guided.yml
+++ b/.github/workflows/demo-guided.yml
@@ -36,6 +36,7 @@ permissions:
 env:
   GROQ_MODEL: ${{ inputs.model }}
   TRIALS: ${{ inputs.trials }}
+  # Choice inputs surface as strings; normalize to 1/0 for shell scripts.
   DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
   RISK_TEXT: ${{ inputs.risk_text }}
 
@@ -138,6 +139,7 @@ jobs:
     env:
       PYTHONUTF8: "1"
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      # Reuse the workflow-scoped flag so shell scripts see consistent 1/0 values.
       DRY_RUN: ${{ env.DRY_RUN }}
       STREAM: '0'
       GROQ_MODEL: ${{ inputs.model }}


### PR DESCRIPTION
## Summary
- document how the workflow normalizes the dry-run choice input into shell-friendly values
- add context on the execute job reusing the workflow-scoped dry-run flag for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d68aa662ac83299d1616adef03e01b