### PR TITLE
ci(guided): fix env reference in execute job

### DIFF
--- a/.github/workflows/demo-guided.yml
+++ b/.github/workflows/demo-guided.yml
@@ -139,8 +139,8 @@ jobs:
     env:
       PYTHONUTF8: "1"
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      # Reuse the workflow-scoped flag so shell scripts see consistent 1/0 values.
-      DRY_RUN: ${{ env.DRY_RUN }}
+      # Derive 1/0 from the workflow input directly (don't reference env.* here)
+      DRY_RUN: ${{ inputs.dry_run == 'true' && '1' || '0' }}
       STREAM: '0'
       GROQ_MODEL: ${{ inputs.model }}
       RISK_TEXT: ${{ inputs.risk_text }}


### PR DESCRIPTION
## Summary
- derive the execute job's DRY_RUN flag directly from the workflow input to avoid env lookup errors

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d68d9693a88329a114fbfc113394ee