### PR TITLE
report: add literal trial I/O table with expand/collapse

### DIFF
--- a/tools/report_utils.py
+++ b/tools/report_utils.py
@@ -1,0 +1,52 @@
+"""Utility helpers for building HTML report content."""
+from __future__ import annotations
+
+import html
+from typing import Mapping, Any
+
+
+def truncate_for_preview(text: str, limit: int = 240) -> str:
+    """Return a shortened preview string limited to ``limit`` characters.
+
+    The preview keeps whitespace intact and appends an ellipsis when the
+    original text exceeds the limit.
+    """
+
+    if text is None:
+        return ""
+    if limit <= 0:
+        return ""
+    clean = str(text)
+    if len(clean) <= limit:
+        return clean
+    return clean[:limit].rstrip() + "…"
+
+
+def expandable_block(block_id: str, preview: str, full: str) -> str:
+    """Return an HTML block with a preview, toggle button, and full text."""
+
+    safe_id = html.escape(block_id, quote=True)
+    preview_html = html.escape(preview or "", quote=False)
+    full_html = html.escape(full or "", quote=False)
+    return (
+        f"<div class=\"expander\">"
+        f"<div class=\"preview\">{preview_html}</div>"
+        f"<button type=\"button\" class=\"toggle\" data-expands=\"{safe_id}\">Expand</button>"
+        f"<div class=\"fulltext\" id=\"{safe_id}\">{full_html}</div>"
+        "</div>"
+    )
+
+
+def safe_get(mapping: Mapping[str, Any] | None, key: str, default: str = "—") -> str:
+    """Return a printable string for ``mapping[key]`` or ``default``.
+
+    ``None`` values, missing keys, and empty strings collapse to the default
+    placeholder to keep table rendering consistent.
+    """
+
+    if not isinstance(mapping, Mapping):
+        return default
+    value = mapping.get(key, default)
+    if value in (None, ""):
+        return default
+    return str(value)

--- a/tools/schemas/rows.schema.json
+++ b/tools/schemas/rows.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DoomArena rows.jsonl row",
+  "type": "object",
+  "description": "Schema fragment describing the per-call records emitted in rows.jsonl.",
+  "properties": {
+    "trial_id": {
+      "type": ["string", "integer", "null"],
+      "description": "Identifier for the logical trial or case that this call belongs to."
+    },
+    "trial_index": {
+      "type": ["integer", "null"],
+      "description": "Zero-based index of the trial iteration within the run."
+    },
+    "callable": {
+      "type": ["boolean", "null"],
+      "description": "True when the underlying model call executed. False or null indicates the attack was blocked before invocation."
+    },
+    "success": {
+      "type": ["boolean", "null"],
+      "description": "True when the call satisfied the evaluator's success criteria."
+    },
+    "pre_gate": {
+      "type": ["object", "string", "null"],
+      "description": "Reason metadata returned by the pre-call safety gate. Objects commonly include decision, reason_code, and rule_id."
+    },
+    "post_gate": {
+      "type": ["object", "string", "null"],
+      "description": "Reason metadata returned by the post-call safety gate. Objects commonly include decision, reason_code, and rule_id."
+    },
+    "input_case": {
+      "type": ["object", "null"],
+      "description": "Input case metadata describing the attack prompt and contextual identifiers.",
+      "properties": {
+        "prompt": {
+          "type": ["string", "null"],
+          "description": "Literal prompt string sent to the callable target."
+        },
+        "attack_prompt": {
+          "type": ["string", "null"],
+          "description": "Alias for prompt used in earlier pipeline versions."
+        }
+      }
+    },
+    "model_response": {
+      "type": ["string", "null"],
+      "description": "Literal text returned from the model or callable after execution."
+    }
+  },
+  "additionalProperties": true
+}

--- a/tools/templates/report.html.j2
+++ b/tools/templates/report.html.j2
@@ -1,0 +1,28 @@
+<section id="trial-io">
+  <h2>Trial I/O</h2>
+  $banner
+  $table_html
+  <p class="muted">Raw artifacts: <a href="$rel_root/rows.jsonl">rows.jsonl</a> · <a href="$rel_root/summary.csv">summary.csv</a></p>
+</section>
+<script>
+// tiny toggler; no deps
+document.addEventListener('click', function(e){
+  if (e.target && e.target.matches('[data-expands]')) {
+    const id = e.target.getAttribute('data-expands');
+    const full = document.getElementById(id);
+    if (!full) return;
+    const expanded = full.style.display === 'block';
+    full.style.display = expanded ? 'none' : 'block';
+    e.target.textContent = expanded ? 'Expand' : 'Collapse';
+  }
+});
+</script>
+<style>
+  .io-table{width:100%; border-collapse:collapse}
+  .io-table th,.io-table td{border:1px solid #ddd; padding:8px; vertical-align:top}
+  .muted{opacity:.75; font-size:.9em}
+  .preview{white-space:pre-wrap}
+  .fulltext{display:none; white-space:pre-wrap; margin-top:.5rem}
+  .toggle{cursor:pointer; border:none; background:#eee; padding:.25rem .5rem; border-radius:.25rem}
+  .expander{display:flex; flex-direction:column; gap:.5rem}
+</style>


### PR DESCRIPTION
## Summary
- stream callable rows to build a round-robin trial I/O table with expandable prompt/response previews
- add reusable report utilities and HTML template for the trial table plus document relevant fields in rows.schema.json

## Testing
- python -m compileall tools
- python tools/mk_report.py /tmp/demo_run

------
https://chatgpt.com/codex/tasks/task_e_68d6f7d702548329ada20d4875b8de99