### PR TITLE
runner+report: persist literal input_text/output_text in rows.jsonl and render per-attempt I/O table with success icons

### DIFF
--- a/tools/mk_report.py
+++ b/tools/mk_report.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import sys
+from html import escape
 from pathlib import Path
 from string import Template
 from typing import Any, Dict, Iterator, Mapping, Optional, Tuple
@@ -29,14 +30,57 @@ except Exception:  # fallback for older runners
         return html.escape(str(s), quote=True)
 
 try:
-    from tools.report_utils import (
-        expandable_block,
-        get_prompt,
-        get_response,
-        safe_get,
-    )
+    from tools.report_utils import safe_get
 except ModuleNotFoundError:  # pragma: no cover - script invoked from tools/
-    from report_utils import expandable_block, get_prompt, get_response, safe_get
+    from report_utils import safe_get  # type: ignore
+
+
+PROMPT_KEYS = [
+    ("input_text", None),
+    ("input_case", "prompt"),
+    ("input", "prompt"),
+    ("attack_prompt", None),
+    ("prompt", None),
+]
+
+
+RESPONSE_KEYS = [
+    ("output_text", None),
+    ("model_response", None),
+    ("response", "text"),
+    ("response", None),
+    ("output", None),
+    ("model_output", None),
+]
+
+
+def pick(row: Mapping[str, Any], keys: list[tuple[str, Optional[str]]]) -> str:
+    for outer, inner in keys:
+        value = row.get(outer)
+        if inner is None:
+            if value:
+                return str(value)
+            continue
+        if isinstance(value, Mapping):
+            candidate = value.get(inner)
+            if candidate:
+                return str(candidate)
+    return "—"
+
+
+def expander(block_id: str, text: str, limit: int = 240) -> str:
+    full_text = text or ""
+    preview = full_text[:limit] + ("…" if len(full_text) > limit else "")
+    safe_id = escape(block_id, quote=True)
+    preview_html = escape(preview, quote=False)
+    full_html = escape(full_text, quote=False)
+    return (
+        '<div class="expander">'
+        f'<div class="preview">{preview_html}</div>'
+        f'<div id="{safe_id}" class="fulltext" style="display:none;">{full_html}</div>'
+        f'<button class="toggle" data-expands="{safe_id}">Expand</button>'
+        "</div>"
+    )
 
 
 def _read_jsonl_lines(p: Path) -> Iterator[Dict[str, Any]]:
@@ -164,8 +208,14 @@ def _load_trial_template() -> Template:
         text = (
             "<section id=\"trial-io\">"
             "<h2>Trial I/O</h2>"
-            "$banner\n"
-            "$table_html\n"
+            "<p class=\"muted\">$status_line</p>"
+            "<table class=\"io-table\">"
+            "<thead><tr><th>trial_id</th><th>callable</th><th>pre_gate</th>"
+            "<th>post_gate</th><th>success</th><th>input</th><th>output</th></tr></thead>"
+            "<tbody>$table_rows</tbody>"
+            "</table>"
+            "<p class=\"muted\">Raw artifacts: <a href=\"$rel_root/rows.jsonl\">rows.jsonl</a> · "
+            "<a href=\"$rel_root/summary.csv\">summary.csv</a></p>"
             "</section>"
         )
     return Template(text)
@@ -178,6 +228,12 @@ def _escape_for_template(value: str) -> str:
 
 
 def _format_success(value: Any) -> str:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return "✅"
+        if normalized in {"false", "0", "no"}:
+            return "❌"
     if value is True:
         return "✅"
     if value is False:
@@ -223,16 +279,22 @@ def _resolve_trial_id(row: Mapping[str, Any], fallback_index: int) -> str:
     return str(fallback_index)
 
 
+def _normalize_for_expander(value: str) -> str:
+    if value is None or value == "—":
+        return ""
+    return value
+
+
 def _build_trial_row(row: Mapping[str, Any], index: int) -> Dict[str, str]:
     trial_id_raw = _resolve_trial_id(row, index)
-    prompt_txt = get_prompt(row) or ""
-    response_txt = get_response(row) or ""
+    prompt_txt = pick(row, PROMPT_KEYS)
+    response_txt = pick(row, RESPONSE_KEYS)
 
-    prompt_html = expandable_block(f"p-{trial_id_raw}", prompt_txt)
-    response_html = expandable_block(f"r-{trial_id_raw}", response_txt)
+    prompt_html = expander(f"p-{trial_id_raw}", _normalize_for_expander(prompt_txt))
+    response_html = expander(f"r-{trial_id_raw}", _normalize_for_expander(response_txt))
 
     success_value = row.get("success")
-    if success_value in (None, ""):
+    if success_value in (None, "", "—"):
         success_value = row.get("judge_success")
 
     return {
@@ -292,18 +354,6 @@ def render_trial_io_section(run_dir: Path, *, trial_limit: int) -> str:
     rows_path = _find_rows_file(run_dir)
     rel_root = "."
 
-    if not rows_path:
-        return template.substitute(
-            banner=_escape_for_template(
-                "<p class=\"muted\">No per-trial rows found (rows.jsonl missing).</p>"
-            ),
-            table_html="",
-            rel_root=rel_root,
-            shown_n=0,
-            total_callable=0,
-            total_trials=0,
-        )
-
     run_meta = _load_run_meta(run_dir)
     total_trials_meta: Any = run_meta.get("trials")
     if total_trials_meta is None:
@@ -316,48 +366,39 @@ def render_trial_io_section(run_dir: Path, *, trial_limit: int) -> str:
     cap = trial_limit if trial_limit > 0 else MAX_TABLE_ROWS
     cap = min(cap, MAX_TABLE_ROWS)
 
-    table_rows, total_callable = _collect_trial_rows(rows_path, cap)
-    shown_n = len(table_rows)
-    rows_html = _render_trial_table_rows(table_rows)
-
-    if total_trials == "—":
+    if not rows_path:
+        status_line = "No per-trial rows found (rows.jsonl missing)."
+        rows_html = '<tr><td colspan="7" class="muted">No rows recorded.</td></tr>'
+        table_rows: list[Dict[str, str]] = []
+        shown_n = 0
+        total_callable = 0
         trials_display = "—"
     else:
-        trials_display = str(total_trials)
+        table_rows, total_callable = _collect_trial_rows(rows_path, cap)
+        shown_n = len(table_rows)
+        rows_html = _render_trial_table_rows(table_rows)
+        trials_display = str(total_trials) if total_trials != "—" else "—"
 
-    if total_callable == 0:
-        banner = "<p class=\"muted\">No callable trials—check pre/post gates or budgets.</p>"
-        table_html = ""
-    else:
-        banner = (
-            "<p class=\"muted\">showing "
-            f"{shown_n} of {total_callable} callable trials; round-robin across {trials_display} trials."  # noqa: E501
-            "</p>"
-        )
-        table_html = (
-            "<table class=\"io-table\">"
-            "<thead>"
-            "<tr>"
-            "<th>trial_id</th><th>callable</th><th>pre_gate</th>"
-            "<th>post_gate</th><th>success</th><th>prompt</th><th>response</th>"
-            "</tr>"
-            "</thead>"
-            "<tbody>"
-            f"{rows_html}"
-            "</tbody>"
-            "</table>"
-        )
+        if total_callable == 0:
+            status_line = "No callable trials—check pre/post gates or budgets."
+            if not rows_html:
+                rows_html = '<tr><td colspan="7" class="muted">No callable trials recorded.</td></tr>'
+        else:
+            status_line = (
+                "showing "
+                f"{shown_n} of {total_callable} callable trials; round-robin across {trials_display} trials"
+            )
 
     context = {
-        "trial_table": table_rows,
+        "trial_table": table_rows if rows_path else [],
         "shown_n": shown_n,
         "total_callable": total_callable,
         "total_trials": trials_display,
     }
 
     return template.substitute(
-        banner=_escape_for_template(banner),
-        table_html=_escape_for_template(table_html),
+        status_line=_escape_for_template(status_line),
+        table_rows=_escape_for_template(rows_html),
         rel_root=rel_root,
         shown_n=shown_n,
         total_callable=total_callable,

--- a/tools/mk_report.py
+++ b/tools/mk_report.py
@@ -30,9 +30,9 @@ except Exception:  # fallback for older runners
         return html.escape(str(s), quote=True)
 
 try:
-    from tools.report_utils import safe_get
+    from tools.report_utils import get_prompt, get_response, safe_get
 except ModuleNotFoundError:  # pragma: no cover - script invoked from tools/
-    from report_utils import safe_get  # type: ignore
+    from report_utils import get_prompt, get_response, safe_get  # type: ignore
 
 
 PROMPT_KEYS = [
@@ -288,7 +288,16 @@ def _normalize_for_expander(value: str) -> str:
 def _build_trial_row(row: Mapping[str, Any], index: int) -> Dict[str, str]:
     trial_id_raw = _resolve_trial_id(row, index)
     prompt_txt = pick(row, PROMPT_KEYS)
+    if prompt_txt == "—":
+        legacy_prompt = get_prompt(row)
+        if legacy_prompt:
+            prompt_txt = legacy_prompt
+
     response_txt = pick(row, RESPONSE_KEYS)
+    if response_txt == "—":
+        legacy_response = get_response(row)
+        if legacy_response:
+            response_txt = legacy_response
 
     prompt_html = expander(f"p-{trial_id_raw}", _normalize_for_expander(prompt_txt))
     response_html = expander(f"r-{trial_id_raw}", _normalize_for_expander(response_txt))

--- a/tools/run_real.py
+++ b/tools/run_real.py
@@ -1,0 +1,249 @@
+"""Utilities for executing REAL runs and streaming per-attempt rows."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+CaseLike = Mapping[str, Any]
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, Mapping):
+        for key in ("text", "content", "message", "value"):
+            if key in value:
+                return _stringify(value.get(key))
+        choices = value.get("choices")
+        if isinstance(choices, Iterable) and not isinstance(choices, (str, bytes, bytearray)):
+            parts = [_stringify(item) for item in choices]
+            return "\n".join(part for part in parts if part)
+        return ""
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes, bytearray)):
+        parts = [_stringify(item) for item in value]
+        return "\n".join(part for part in parts if part)
+    return str(value)
+
+
+def build_final_prompt(case: CaseLike) -> str:
+    """Return the literal prompt string sent to the model for ``case``."""
+
+    for key in ("input_text", "raw_input"):
+        value = case.get(key)
+        if value:
+            return _stringify(value)
+
+    input_case = case.get("input_case")
+    if isinstance(input_case, Mapping):
+        for key in ("prompt", "attack_prompt", "input_text"):
+            value = input_case.get(key)
+            if value:
+                return _stringify(value)
+
+    for key in ("prompt", "attack_prompt", "request"):
+        value = case.get(key)
+        if value:
+            return _stringify(value)
+
+    messages = None
+    candidate_messages = case.get("messages")
+    if isinstance(candidate_messages, Iterable) and not isinstance(
+        candidate_messages, (str, bytes, bytearray)
+    ):
+        messages = candidate_messages
+    elif isinstance(case.get("input"), Mapping):
+        inner_messages = case["input"].get("messages")
+        if isinstance(inner_messages, Iterable) and not isinstance(
+            inner_messages, (str, bytes, bytearray)
+        ):
+            messages = inner_messages
+    if messages:
+        parts = []
+        for message in messages:
+            if not isinstance(message, Mapping):
+                continue
+            role = message.get("role")
+            if role not in {"user", "system"}:
+                continue
+            text = _stringify(message.get("content"))
+            if text:
+                parts.append(text)
+        if parts:
+            return "\n".join(parts)
+
+    return ""
+
+
+def extract_text(response: Any) -> str:
+    """Extract a printable string from ``response``."""
+
+    if response is None:
+        return ""
+    if isinstance(response, str):
+        return response
+    if isinstance(response, (int, float)):
+        return str(response)
+    if isinstance(response, Mapping):
+        for key in ("output_text", "text", "content", "message", "value"):
+            if key in response:
+                return extract_text(response.get(key))
+        choices = response.get("choices")
+        if isinstance(choices, Iterable) and not isinstance(choices, (str, bytes, bytearray)):
+            parts = [extract_text(item) for item in choices]
+            return "\n".join(part for part in parts if part)
+        return ""
+    if isinstance(response, Iterable) and not isinstance(response, (str, bytes, bytearray)):
+        parts = [extract_text(item) for item in response]
+        return "\n".join(part for part in parts if part)
+    return str(response)
+
+
+def _combine_model_args(
+    base: Mapping[str, Any] | None, override: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    combined: dict[str, Any] = {}
+    if base:
+        combined.update(dict(base))
+    if override:
+        combined.update({k: v for k, v in override.items()})
+    return combined
+
+
+def _derive_base_row(case: CaseLike, override: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    row: dict[str, Any] = {}
+    if override:
+        row.update(override)
+
+    for key in ("trial_id", "trial", "trial_index"):
+        if key not in row and case.get(key) is not None:
+            row[key] = case.get(key)
+    if "callable" not in row:
+        row["callable"] = bool(case.get("callable", True))
+    if "success" not in row and case.get("success") is not None:
+        row["success"] = case.get("success")
+
+    for key in ("pre_gate", "post_gate"):
+        if key not in row and case.get(key) is not None:
+            row[key] = case.get(key)
+
+    return row
+
+
+def persist_attempt(
+    case: CaseLike,
+    *,
+    rows_path: os.PathLike[str] | str,
+    call_model: Callable[..., Any],
+    model_args: Mapping[str, Any] | None = None,
+    prompt_builder: Callable[[CaseLike], str] = build_final_prompt,
+    response_parser: Callable[[Any], str] = extract_text,
+    evaluator: Callable[[CaseLike, str, str, Any], Mapping[str, Any]] | None = None,
+    row_overrides: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute a single REAL attempt and persist the resulting row."""
+
+    rows_file = Path(rows_path)
+    rows_file.parent.mkdir(parents=True, exist_ok=True)
+
+    attack_prompt = case.get("attack_prompt")
+    if not attack_prompt:
+        input_case = case.get("input_case")
+        if isinstance(input_case, Mapping):
+            attack_prompt = input_case.get("prompt") or input_case.get("attack_prompt")
+    if not attack_prompt:
+        attack_prompt = case.get("prompt")
+
+    input_text = prompt_builder(case) or ""
+
+    per_attempt_model_args = None
+    candidate_args = case.get("model_args")
+    if isinstance(candidate_args, Mapping):
+        per_attempt_model_args = candidate_args
+    args = _combine_model_args(model_args, per_attempt_model_args)
+
+    start = time.time()
+    response = call_model(input_text, **args)
+    latency_ms = int((time.time() - start) * 1000)
+
+    output_text = response_parser(response) or ""
+
+    eval_result: Mapping[str, Any] | None = None
+    if evaluator is not None:
+        try:
+            eval_result = evaluator(case, input_text, output_text, response) or {}
+        except Exception:
+            eval_result = {}
+
+    base_row = _derive_base_row(case, row_overrides)
+
+    success_value: Any = None
+    if eval_result and "success" in eval_result:
+        success_value = eval_result.get("success")
+    elif "success" in base_row:
+        success_value = base_row.get("success")
+    base_row["success"] = bool(success_value) if success_value is not None else False
+
+    base_row.update(
+        {
+            "attack_id": case.get("attack_id", "—"),
+            "attack_prompt": attack_prompt or "—",
+            "input_text": input_text,
+            "output_text": output_text,
+            "latency_ms": latency_ms,
+        }
+    )
+
+    with rows_file.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(base_row, ensure_ascii=False) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    return base_row
+
+
+def run_attempts(
+    cases: Iterable[CaseLike],
+    *,
+    rows_path: os.PathLike[str] | str,
+    call_model: Callable[..., Any],
+    model_args: Mapping[str, Any] | None = None,
+    prompt_builder: Callable[[CaseLike], str] = build_final_prompt,
+    response_parser: Callable[[Any], str] = extract_text,
+    evaluator: Callable[[CaseLike, str, str, Any], Mapping[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Execute a sequence of REAL attempts and persist each row immediately."""
+
+    rows: list[dict[str, Any]] = []
+    for case in cases:
+        overrides = None
+        if isinstance(case.get("row"), Mapping):
+            overrides = case.get("row")
+        rows.append(
+            persist_attempt(
+                case,
+                rows_path=rows_path,
+                call_model=call_model,
+                model_args=model_args,
+                prompt_builder=prompt_builder,
+                response_parser=response_parser,
+                evaluator=evaluator,
+                row_overrides=overrides,
+            )
+        )
+    return rows
+
+
+__all__ = [
+    "build_final_prompt",
+    "extract_text",
+    "persist_attempt",
+    "run_attempts",
+]

--- a/tools/schemas/rows.schema.json
+++ b/tools/schemas/rows.schema.json
@@ -45,6 +45,18 @@
     "model_response": {
       "type": ["string", "null"],
       "description": "Literal text returned from the model or callable after execution."
+    },
+    "attack_prompt": {
+      "type": ["string", "null"],
+      "description": "Original attack prompt text associated with the attempt."
+    },
+    "input_text": {
+      "type": ["string", "null"],
+      "description": "Exact literal prompt string sent to the model after templating."
+    },
+    "output_text": {
+      "type": ["string", "null"],
+      "description": "Exact literal text returned from the model without post-processing."
     }
   },
   "additionalProperties": true

--- a/tools/templates/report.html.j2
+++ b/tools/templates/report.html.j2
@@ -1,28 +1,37 @@
 <section id="trial-io">
   <h2>Trial I/O</h2>
-  $banner
-  $table_html
+  <p class="muted">$status_line</p>
+  <table class="io-table">
+    <thead>
+      <tr>
+        <th>trial_id</th><th>callable</th><th>pre_gate</th><th>post_gate</th><th>success</th><th>input</th><th>output</th>
+      </tr>
+    </thead>
+    <tbody>
+      $table_rows
+    </tbody>
+  </table>
   <p class="muted">Raw artifacts: <a href="$rel_root/rows.jsonl">rows.jsonl</a> · <a href="$rel_root/summary.csv">summary.csv</a></p>
 </section>
 <script>
-// tiny toggler; no deps
 document.addEventListener('click', function(e){
-  if (e.target && e.target.matches('[data-expands]')) {
-    const id = e.target.getAttribute('data-expands');
+  const t = e.target;
+  if (t && t.matches('[data-expands]')) {
+    const id = t.getAttribute('data-expands');
     const full = document.getElementById(id);
     if (!full) return;
-    const expanded = full.style.display === 'block';
-    full.style.display = expanded ? 'none' : 'block';
-    e.target.textContent = expanded ? 'Expand' : 'Collapse';
+    const open = full.style.display === 'block';
+    full.style.display = open ? 'none' : 'block';
+    t.textContent = open ? 'Expand' : 'Collapse';
   }
 });
 </script>
 <style>
-  .io-table{width:100%; border-collapse:collapse}
-  .io-table th,.io-table td{border:1px solid #ddd; padding:8px; vertical-align:top}
-  .muted{opacity:.75; font-size:.9em}
-  .preview{white-space:pre-wrap}
-  .fulltext{display:none; white-space:pre-wrap; margin-top:.5rem}
-  .toggle{cursor:pointer; border:none; background:#eee; padding:.25rem .5rem; border-radius:.25rem}
-  .expander{display:flex; flex-direction:column; gap:.5rem}
+.io-table{width:100%; border-collapse:collapse}
+.io-table th,.io-table td{border:1px solid #ddd; padding:8px; vertical-align:top}
+.muted{opacity:.75; font-size:.9em}
+.preview,.fulltext{white-space:pre-wrap}
+.fulltext{display:none; margin-top:.5rem}
+.toggle{cursor:pointer; border:none; background:#eee; padding:.25rem .5rem; border-radius:.25rem}
+.expander{display:flex; flex-direction:column; gap:.5rem}
 </style>

--- a/tools/tests/test_report_table.py
+++ b/tools/tests/test_report_table.py
@@ -72,6 +72,9 @@ def test_trial_table_lists_all_callable_attempts(tmp_path):
     assert "Attack 0 Trial 0" in section_html
     assert "Response 0-0" in section_html
 
-    full_blocks = re.findall(r'<div class="fulltext" id="[^"]+">(.*?)</div>', section_html, re.DOTALL)
+    full_blocks = re.findall(r'<div[^>]*class="fulltext"[^>]*>(.*?)</div>', section_html, re.DOTALL)
     assert len(full_blocks) >= 80
     assert all(block.strip() for block in full_blocks)
+
+    assert "<th>input</th>" in section_html
+    assert "<th>output</th>" in section_html

--- a/tools/tests/test_rows_io_persistence.py
+++ b/tools/tests/test_rows_io_persistence.py
@@ -1,0 +1,70 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+RUN_REAL_PATH = Path(__file__).resolve().parents[1] / "run_real.py"
+spec = importlib.util.spec_from_file_location("run_real", RUN_REAL_PATH)
+assert spec and spec.loader
+run_real = importlib.util.module_from_spec(spec)
+tools_dir = RUN_REAL_PATH.parent
+sys.path.insert(0, str(tools_dir))
+sys.modules[spec.name] = run_real
+spec.loader.exec_module(run_real)
+
+
+def test_rows_capture_literal_io(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    rows_path = run_dir / "rows.jsonl"
+
+    prompts_seen: list[str] = []
+    outputs_seen: list[str] = []
+
+    def fake_call_model(prompt: str, **kwargs):
+        prompts_seen.append(prompt)
+        attack = kwargs.get("attack", "?")
+        trial = kwargs.get("trial", "?")
+        output = f"output::{attack}-{trial}::{prompt.splitlines()[-1]}"
+        outputs_seen.append(output)
+        return {"text": output}
+
+    cases = []
+    for attack_idx in range(4):
+        for trial_idx in range(10):
+            prompt = f"Attack {attack_idx} Trial {trial_idx}\nPrompt line {trial_idx}"
+            case = {
+                "attack_id": f"a{attack_idx}",
+                "trial_id": f"{attack_idx}-{trial_idx}",
+                "attack_prompt": f"Attack {attack_idx} seed prompt",
+                "prompt": prompt,
+                "row": {
+                    "callable": True,
+                    "pre_gate": {"decision": "allow"},
+                    "post_gate": {"decision": "allow"},
+                    "success": trial_idx % 2 == 0,
+                },
+                "model_args": {"attack": attack_idx, "trial": trial_idx},
+            }
+            cases.append(case)
+
+    run_real.run_attempts(cases, rows_path=rows_path, call_model=fake_call_model)
+
+    assert rows_path.exists()
+    assert len(prompts_seen) == 40
+
+    lines = rows_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 40
+
+    for idx, line in enumerate(lines):
+        payload = json.loads(line)
+        assert payload["input_text"], f"row {idx} missing input_text"
+        assert payload["output_text"], f"row {idx} missing output_text"
+        assert payload["input_text"].endswith(f"Prompt line {idx % 10}")
+        assert payload["output_text"] == outputs_seen[idx]
+        assert payload["attack_prompt"] == f"Attack {payload['attack_id'][1:]} seed prompt"
+        assert payload["latency_ms"] >= 0
+        assert isinstance(payload["success"], bool)
+
+    assert prompts_seen[0] == "Attack 0 Trial 0\nPrompt line 0"
+    assert outputs_seen[0].startswith("output::0-0::")


### PR DESCRIPTION
## Summary
- add a reusable REAL runner helper that records exact prompts and responses per attempt, flushing rows.jsonl immediately
- update mk_report and the report template to pick up the new fields, render expandable I/O columns, and keep fallbacks for legacy rows
- extend the rows schema and test suite to cover the new fields and ensure literal inputs/outputs persist across 40 callable trials

## Testing
- pytest tools/tests

------
https://chatgpt.com/codex/tasks/task_e_68d7d0384e4883298e07c477db5b46ac