### PR TITLE
debug(report): add diagnosis artifacts for empty Trial I/O table

### DIFF
--- a/tools/debug/print_rows.py
+++ b/tools/debug/print_rows.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Inspect ``rows.jsonl`` and surface prompt/response candidates per row."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+try:
+    from tools.report_utils import get_prompt, get_response
+except ModuleNotFoundError:  # pragma: no cover - allow running from tools/
+    from report_utils import get_prompt, get_response  # type: ignore
+
+PROMPT_KEYS: tuple[tuple[str, str | None], ...] = (
+    ("input_text", None),
+    ("input_case", "prompt"),
+    ("input", "prompt"),
+    ("attack_prompt", None),
+    ("prompt", None),
+)
+
+RESPONSE_KEYS: tuple[tuple[str, str | None], ...] = (
+    ("output_text", None),
+    ("model_response", None),
+    ("response", "text"),
+    ("response", None),
+    ("output", None),
+    ("model_output", None),
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _resolve(row: Mapping[str, Any], keys: Iterable[tuple[str, str | None]]) -> tuple[str, str]:
+    for outer, inner in keys:
+        value = row.get(outer)
+        if inner is None:
+            if value not in (None, "", "—"):
+                return outer, _stringify(value)
+            continue
+        if isinstance(value, Mapping):
+            candidate = value.get(inner)
+            if candidate not in (None, "", "—"):
+                return f"{outer}.{inner}", _stringify(candidate)
+    return "", ""
+
+
+def _shorten(text: str, limit: int = 200) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def inspect_rows(path: Path, *, limit: int = 10) -> None:
+    shown = 0
+    with path.open("r", encoding="utf-8") as handle:
+        for idx, raw in enumerate(handle):
+            if shown >= limit:
+                break
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                print(f"[row {idx}] !! malformed JSON")
+                continue
+            if payload.get("callable") is not True:
+                continue
+            prompt_key, prompt_value = _resolve(payload, PROMPT_KEYS)
+            response_key, response_value = _resolve(payload, RESPONSE_KEYS)
+            print(f"[row {idx}] trial_id={payload.get('trial_id', '?')} attack_id={payload.get('attack_id', '?')}")
+            print(f"  prompt key: {prompt_key or '—'}")
+            print(f"  prompt val: {_shorten(prompt_value) or '—'}")
+            print(f"  fallback prompt: {_shorten(get_prompt(payload)) or '—'}")
+            print(f"  response key: {response_key or '—'}")
+            print(f"  response val: {_shorten(response_value) or '—'}")
+            print(f"  fallback response: {_shorten(get_response(payload)) or '—'}")
+            shown += 1
+    if shown == 0:
+        print("No callable rows found in", path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("rows", type=Path, help="Path to rows.jsonl")
+    parser.add_argument("--limit", type=int, default=10, help="Maximum callable rows to display")
+    args = parser.parse_args()
+    inspect_rows(args.rows, limit=max(1, args.limit))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual inspection utility
+    main()

--- a/tools/mk_report.py
+++ b/tools/mk_report.py
@@ -289,12 +289,14 @@ def _build_trial_row(row: Mapping[str, Any], index: int) -> Dict[str, str]:
     trial_id_raw = _resolve_trial_id(row, index)
     prompt_txt = pick(row, PROMPT_KEYS)
     if prompt_txt == "—":
+        # TODO: handle rows where only legacy keys like request.payload/messages carry the prompt.
         legacy_prompt = get_prompt(row)
         if legacy_prompt:
             prompt_txt = legacy_prompt
 
     response_txt = pick(row, RESPONSE_KEYS)
     if response_txt == "—":
+        # TODO: add explicit fallbacks for structured responses (e.g. response.payload.choices).
         legacy_response = get_response(row)
         if legacy_response:
             response_txt = legacy_response

--- a/tools/run_real.py
+++ b/tools/run_real.py
@@ -162,6 +162,8 @@ def persist_attempt(
         attack_prompt = case.get("prompt")
 
     input_text = prompt_builder(case) or ""
+    # TODO: prompt_builder returns "" for cases that only expose system/user templates;
+    # ensure the literal combined prompt is persisted for report replay.
 
     per_attempt_model_args = None
     candidate_args = case.get("model_args")
@@ -174,6 +176,7 @@ def persist_attempt(
     latency_ms = int((time.time() - start) * 1000)
 
     output_text = response_parser(response) or ""
+    # TODO: confirm response_parser captures the raw assistant text used in reports.
 
     eval_result: Mapping[str, Any] | None = None
     if evaluator is not None:

--- a/tools/templates/report.html.j2
+++ b/tools/templates/report.html.j2
@@ -8,6 +8,7 @@
       </tr>
     </thead>
     <tbody>
+      <!-- TODO: prompt_html/response_html are empty when rows only contain placeholder values (see DIAGNOSIS). -->
       $table_rows
     </tbody>
   </table>

--- a/tools/tests/test_trial_io_end_to_end.py
+++ b/tools/tests/test_trial_io_end_to_end.py
@@ -1,0 +1,55 @@
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+MK_REPORT_PATH = Path(__file__).resolve().parents[1] / "mk_report.py"
+spec = importlib.util.spec_from_file_location("mk_report", MK_REPORT_PATH)
+assert spec and spec.loader
+mk_report = importlib.util.module_from_spec(spec)
+tools_dir = MK_REPORT_PATH.parent
+sys.path.insert(0, str(tools_dir))
+sys.modules[spec.name] = mk_report
+spec.loader.exec_module(mk_report)
+
+
+def _blank_row(trial_idx: int) -> dict[str, object]:
+    return {
+        "trial_id": f"trial-{trial_idx}",
+        "attack_id": f"attack-{trial_idx}",
+        "callable": True,
+        "attack_prompt": "—",
+        "model_response": "—",
+        "pre_gate": {"decision": "allow", "reason": f"seed-{trial_idx}"},
+        "post_gate": {"decision": "allow", "reason": f"seed-{trial_idx}"},
+    }
+
+
+def test_trial_io_section_loses_prompt_and_response(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    rows_path = run_dir / "rows.jsonl"
+    rows = [json.dumps(_blank_row(idx)) for idx in range(3)]
+    rows_path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    (run_dir / "run.json").write_text(json.dumps({"trials": 3}), encoding="utf-8")
+
+    section_html = mk_report.render_trial_io_section(run_dir, trial_limit=10)
+
+    tbody_match = re.search(r"<tbody>(.*?)</tbody>", section_html, re.DOTALL)
+    assert tbody_match is not None, section_html
+    tbody = tbody_match.group(1)
+
+    row_count = tbody.count("<tr>")
+    assert row_count == 3, f"expected 3 callable rows, saw {row_count}\n{section_html}"
+
+    previews = re.findall(r'<div class="preview">(.*?)</div>', tbody, re.DOTALL)
+    assert previews, section_html
+    empty = sum(1 for preview in previews if not preview.strip())
+    total = len(previews)
+
+    assert empty < total, (
+        f"Expected non-empty prompt/response in report table for callable attempts; got empty for {empty}/{total}."
+    )

--- a/tools/tests/test_trial_io_end_to_end.py
+++ b/tools/tests/test_trial_io_end_to_end.py
@@ -4,6 +4,8 @@ import re
 import sys
 from pathlib import Path
 
+import pytest
+
 MK_REPORT_PATH = Path(__file__).resolve().parents[1] / "mk_report.py"
 spec = importlib.util.spec_from_file_location("mk_report", MK_REPORT_PATH)
 assert spec and spec.loader
@@ -26,6 +28,10 @@ def _blank_row(trial_idx: int) -> dict[str, object]:
     }
 
 
+@pytest.mark.xfail(
+    reason="Trial I/O report currently omits prompt/response for callable rows; awaiting fix.",
+    strict=True,
+)
 def test_trial_io_section_loses_prompt_and_response(tmp_path: Path) -> None:
     run_dir = tmp_path / "run"
     run_dir.mkdir()


### PR DESCRIPTION
## Summary
- add DIAGNOSIS-trial-io.md capturing evidence, repro, and fix plan for missing Trial I/O text
- introduce tools/debug/print_rows.py helper and annotate report builder/template/runner hotspots with TODOs
- add failing end-to-end test covering empty prompt/response rendering

## Testing
- pytest tools/tests/test_trial_io_end_to_end.py *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d682efc48329b74bdfa4adaf07ab