### PR TITLE
runner+report: persist literal Trial I/O and warn on missing previews

### DIFF
--- a/tools/run_real.py
+++ b/tools/run_real.py
@@ -11,6 +11,9 @@ from typing import Any, Callable, Iterable, Mapping
 CaseLike = Mapping[str, Any]
 
 
+EMPTY_SENTINEL = "[EMPTY]"
+
+
 def _stringify(value: Any) -> str:
     if value is None:
         return ""
@@ -30,6 +33,14 @@ def _stringify(value: Any) -> str:
     if isinstance(value, Iterable) and not isinstance(value, (str, bytes, bytearray)):
         parts = [_stringify(item) for item in value]
         return "\n".join(part for part in parts if part)
+    return str(value)
+
+
+def _ensure_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ""
     return str(value)
 
 
@@ -161,7 +172,7 @@ def persist_attempt(
     if not attack_prompt:
         attack_prompt = case.get("prompt")
 
-    input_text = prompt_builder(case) or ""
+    input_text_literal = _ensure_string(prompt_builder(case))
 
     per_attempt_model_args = None
     candidate_args = case.get("model_args")
@@ -170,15 +181,18 @@ def persist_attempt(
     args = _combine_model_args(model_args, per_attempt_model_args)
 
     start = time.time()
-    response = call_model(input_text, **args)
+    response = call_model(input_text_literal, **args)
     latency_ms = int((time.time() - start) * 1000)
 
-    output_text = response_parser(response) or ""
+    parsed_output = response_parser(response)
+    output_text_literal = _ensure_string(parsed_output)
 
     eval_result: Mapping[str, Any] | None = None
     if evaluator is not None:
         try:
-            eval_result = evaluator(case, input_text, output_text, response) or {}
+            eval_result = (
+                evaluator(case, input_text_literal, output_text_literal, response) or {}
+            )
         except Exception:
             eval_result = {}
 
@@ -191,12 +205,17 @@ def persist_attempt(
         success_value = base_row.get("success")
     base_row["success"] = bool(success_value) if success_value is not None else False
 
+    input_text_to_store = input_text_literal if input_text_literal != "" else EMPTY_SENTINEL
+    output_text_to_store = (
+        output_text_literal if output_text_literal != "" else EMPTY_SENTINEL
+    )
+
     base_row.update(
         {
             "attack_id": case.get("attack_id", "—"),
             "attack_prompt": attack_prompt or "—",
-            "input_text": input_text,
-            "output_text": output_text,
+            "input_text": input_text_to_store,
+            "output_text": output_text_to_store,
             "latency_ms": latency_ms,
         }
     )

--- a/tools/templates/report.html.j2
+++ b/tools/templates/report.html.j2
@@ -1,10 +1,11 @@
 <section id="trial-io">
   <h2>Trial I/O</h2>
   <p class="muted">$status_line</p>
+  $warning_banner
   <table class="io-table">
     <thead>
       <tr>
-        <th>trial_id</th><th>callable</th><th>pre_gate</th><th>post_gate</th><th>success</th><th>input</th><th>output</th>
+        <th>trial_id</th><th>attack_id</th><th>success</th><th>input</th><th>output</th>
       </tr>
     </thead>
     <tbody>
@@ -34,4 +35,5 @@ document.addEventListener('click', function(e){
 .fulltext{display:none; margin-top:.5rem}
 .toggle{cursor:pointer; border:none; background:#eee; padding:.25rem .5rem; border-radius:.25rem}
 .expander{display:flex; flex-direction:column; gap:.5rem}
+.warning{background:#fff3cd; border:1px solid #ffeeba; padding:.5rem .75rem; border-radius:.25rem; margin-bottom:.75rem; font-size:.9em}
 </style>

--- a/tools/tests/test_report_table.py
+++ b/tools/tests/test_report_table.py
@@ -21,6 +21,7 @@ def _make_row(attack_idx: int, trial_idx: int) -> dict:
     row: dict[str, object] = {
         "callable": True,
         "trial_id": f"a{attack_idx}-t{trial_idx}",
+        "attack_id": f"a{attack_idx}",
         "pre_gate": {"decision": "allow", "reason": f"attack-{attack_idx}"},
         "post_gate": {"decision": "allow", "rule_id": f"rule-{trial_idx}"},
     }
@@ -78,3 +79,6 @@ def test_trial_table_lists_all_callable_attempts(tmp_path):
 
     assert "<th>input</th>" in section_html
     assert "<th>output</th>" in section_html
+    assert "<th>attack_id</th>" in section_html
+    assert "<td>a0</td>" in section_html
+    assert "WARNING" not in section_html

--- a/tools/tests/test_rows_schema_backcompat.py
+++ b/tools/tests/test_rows_schema_backcompat.py
@@ -1,0 +1,61 @@
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+MK_REPORT_PATH = Path(__file__).resolve().parents[1] / "mk_report.py"
+report_spec = importlib.util.spec_from_file_location("mk_report", MK_REPORT_PATH)
+assert report_spec and report_spec.loader
+
+mk_report = importlib.util.module_from_spec(report_spec)
+sys.path.insert(0, str(MK_REPORT_PATH.parent))
+sys.modules[report_spec.name] = mk_report
+report_spec.loader.exec_module(mk_report)
+
+
+def test_legacy_rows_render_with_fallbacks(tmp_path):
+    run_dir = tmp_path / "legacy"
+    run_dir.mkdir()
+
+    rows_path = run_dir / "rows.jsonl"
+    legacy_rows = [
+        {
+            "callable": True,
+            "trial_id": "legacy-1",
+            "attack_id": "legacy-a",
+            "prompt": "Legacy prompt 1",
+            "response": {"text": "Legacy response 1"},
+        },
+        {
+            "callable": True,
+            "trial": 2,
+            "attack_prompt": "Attack prompt 2",
+            "model_response": "Model response 2",
+        },
+        {
+            "callable": True,
+            "id": "legacy-3",
+            "input_case": {"prompt": "Case prompt 3"},
+            "output": "Output 3",
+        },
+    ]
+
+    rows_path.write_text("\n".join(json.dumps(row) for row in legacy_rows) + "\n", encoding="utf-8")
+    (run_dir / "run.json").write_text(json.dumps({"trials": 3}), encoding="utf-8")
+
+    section_html = mk_report.render_trial_io_section(run_dir, trial_limit=10)
+
+    tbody_match = re.search(r"<tbody>(.*?)</tbody>", section_html, re.DOTALL)
+    assert tbody_match is not None, section_html
+    tbody_html = tbody_match.group(1)
+    assert tbody_html.count("<tr>") == 3
+
+    assert "Legacy prompt 1" in section_html
+    assert "Legacy response 1" in section_html
+    assert "Attack prompt 2" in section_html
+    assert "Model response 2" in section_html
+    assert "Case prompt 3" in section_html
+    assert "Output 3" in section_html
+    assert "legacy-a" in section_html
+    assert "WARNING" not in section_html

--- a/tools/tests/test_trial_io_end_to_end.py
+++ b/tools/tests/test_trial_io_end_to_end.py
@@ -1,0 +1,106 @@
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+RUN_REAL_PATH = Path(__file__).resolve().parents[1] / "run_real.py"
+MK_REPORT_PATH = Path(__file__).resolve().parents[1] / "mk_report.py"
+
+run_spec = importlib.util.spec_from_file_location("run_real", RUN_REAL_PATH)
+report_spec = importlib.util.spec_from_file_location("mk_report", MK_REPORT_PATH)
+assert run_spec and run_spec.loader
+assert report_spec and report_spec.loader
+
+run_real = importlib.util.module_from_spec(run_spec)
+mk_report = importlib.util.module_from_spec(report_spec)
+
+sys.path.insert(0, str(RUN_REAL_PATH.parent))
+sys.modules[run_spec.name] = run_real
+sys.modules[report_spec.name] = mk_report
+run_spec.loader.exec_module(run_real)
+report_spec.loader.exec_module(mk_report)
+
+EMPTY_SENTINEL = "[EMPTY]"
+
+
+def test_trial_io_end_to_end(tmp_path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    rows_path = run_dir / "rows.jsonl"
+
+    expected_outputs: list[str] = []
+    prompts_seen: list[str] = []
+
+    def fake_call_model(prompt: str, **kwargs):
+        prompts_seen.append(prompt)
+        attack = kwargs.get("attack", 0)
+        trial = kwargs.get("trial", 0)
+        pattern = trial % 5
+        if pattern == 0:
+            expected_outputs.append(EMPTY_SENTINEL)
+            return {"text": ""}
+        if pattern == 1:
+            expected_outputs.append(EMPTY_SENTINEL)
+            return None
+        if pattern == 2:
+            choice_text = f"choice::{attack}-{trial}"
+            expected_outputs.append(f"{choice_text}\nline2")
+            return {"choices": [{"text": choice_text}, {"text": "line2"}]}
+        if pattern == 3:
+            iter_text = f"iter::{attack}-{trial}"
+            expected_outputs.append(iter_text)
+            return [iter_text]
+        plain_text = f"plain::{attack}-{trial}"
+        expected_outputs.append(plain_text)
+        return plain_text
+
+    cases = []
+    success_flags: list[bool] = []
+    for attack_idx in range(4):
+        for trial_idx in range(10):
+            prompt = f"Attack {attack_idx} Trial {trial_idx}\nPrompt line {trial_idx}"
+            case = {
+                "attack_id": f"a{attack_idx}",
+                "trial_id": f"{attack_idx}-{trial_idx}",
+                "attack_prompt": f"Attack {attack_idx} seed prompt",
+                "prompt": prompt,
+                "row": {
+                    "callable": True,
+                    "success": bool(trial_idx % 3 == 0),
+                },
+                "model_args": {"attack": attack_idx, "trial": trial_idx},
+            }
+            cases.append(case)
+            success_flags.append(bool(trial_idx % 3 == 0))
+
+    run_real.run_attempts(cases, rows_path=rows_path, call_model=fake_call_model)
+
+    assert len(prompts_seen) == 40
+    lines = rows_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 40
+
+    payloads = [json.loads(line) for line in lines]
+    stored_outputs = [payload["output_text"] for payload in payloads]
+    stored_inputs = [payload["input_text"] for payload in payloads]
+
+    assert stored_inputs == prompts_seen
+    assert stored_outputs == expected_outputs
+    assert sum(1 for text in stored_outputs if text == EMPTY_SENTINEL) == 16
+
+    (run_dir / "run.json").write_text(json.dumps({"trials": 10}), encoding="utf-8")
+
+    section_html = mk_report.render_trial_io_section(run_dir, trial_limit=1000)
+
+    tbody_match = re.search(r"<tbody>(.*?)</tbody>", section_html, re.DOTALL)
+    assert tbody_match is not None, section_html
+    tbody_html = tbody_match.group(1)
+    assert tbody_html.count("<tr>") == 40
+
+    assert section_html.count("✅") == sum(success_flags)
+    assert section_html.count("❌") == len(success_flags) - sum(success_flags)
+
+    assert "[EMPTY]" in section_html
+    assert "WARNING" not in section_html
+    assert "<th>attack_id</th>" in section_html
+    assert "<td>a0</td>" in section_html


### PR DESCRIPTION
## Summary
- ensure `run_real` persists the literal input/output strings for each attempt and replaces empty captures with the `[EMPTY]` sentinel
- update `mk_report` and the Trial I/O template to surface the new literal columns, fall back to legacy fields, and emit a warning banner when most previews are missing
- add regression coverage for a 4×10 Trial I/O run and for legacy row schemas to guard the new rendering paths

## Testing
- `pytest tools/tests`


------
https://chatgpt.com/codex/tasks/task_e_68d7df9bca448329b2c12405c14d1cc5