### PR TITLE
hotfix: sweep runner→rows→report to ensure literal per-attempt I/O; add trace tool, assertive diagnostics, and end-to-end tests

### DIFF
--- a/tools/debug/trace_trial_io.py
+++ b/tools/debug/trace_trial_io.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Inspect callable trial rows to verify prompt/response persistence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - script executed from repo root
+    from tools.report_utils import (
+        EMPTY_SENTINEL,
+        ResolvedField,
+        resolve_prompt_field,
+        resolve_response_field,
+    )
+except ModuleNotFoundError:  # pragma: no cover - script executed from tools/
+    from report_utils import (  # type: ignore
+        EMPTY_SENTINEL,
+        ResolvedField,
+        resolve_prompt_field,
+        resolve_response_field,
+    )
+
+PLACEHOLDER_VALUES = {"", "—", EMPTY_SENTINEL}
+
+
+def _is_placeholder(text: str) -> bool:
+    stripped = text.strip()
+    return stripped in PLACEHOLDER_VALUES
+
+
+def _iter_rows(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError as exc:
+                print(f"[warn] failed to parse line {line_no}: {exc}", file=sys.stderr)
+
+
+def _format_preview(text: str, limit: int = 120) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "…"
+
+
+def _resolve_fields(row: dict[str, Any]) -> tuple[ResolvedField, ResolvedField]:
+    prompt_res = resolve_prompt_field(row)
+    response_res = resolve_response_field(row)
+    return prompt_res, response_res
+
+
+def trace_rows(rows_path: Path, limit: int) -> int:
+    printed = 0
+    placeholder_both = 0
+
+    for row in _iter_rows(rows_path):
+        if row.get("callable") is not True:
+            continue
+        prompt_res, response_res = _resolve_fields(row)
+        prompt_text = prompt_res.text or ""
+        response_text = response_res.text or ""
+
+        prompt_placeholder = _is_placeholder(prompt_text)
+        response_placeholder = _is_placeholder(response_text)
+        if prompt_placeholder and response_placeholder:
+            placeholder_both += 1
+
+        print(
+            f"trial={row.get('trial_id', '—')} attack={row.get('attack_id', '—')} success={row.get('success')}"
+        )
+        print(
+            f"  prompt[{prompt_res.source}]: {_format_preview(prompt_text)}"
+        )
+        print(
+            f"  response[{response_res.source}]: {_format_preview(response_text)}"
+        )
+        print("---")
+
+        printed += 1
+        if printed >= limit:
+            break
+
+    if printed == 0:
+        print("No callable rows found.")
+        return 2
+
+    if placeholder_both / printed > 0.8:
+        return 1
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("rows_path", type=Path, help="Path to rows.jsonl file")
+    parser.add_argument("--k", type=int, default=10, help="Callable rows to inspect (default: 10)")
+    args = parser.parse_args(argv[1:])
+
+    if args.k <= 0:
+        parser.error("--k must be a positive integer")
+
+    if not args.rows_path.exists():
+        parser.error(f"rows file not found: {args.rows_path}")
+
+    return trace_rows(args.rows_path, args.k)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/tests/test_report_table.py
+++ b/tools/tests/test_report_table.py
@@ -82,3 +82,30 @@ def test_trial_table_lists_all_callable_attempts(tmp_path):
     assert "<th>attack_id</th>" in section_html
     assert "<td>a0</td>" in section_html
     assert "WARNING" not in section_html
+
+
+def test_warning_when_placeholders_dominate(tmp_path):
+    run_dir = tmp_path / "warn"
+    run_dir.mkdir()
+
+    rows_path = run_dir / "rows.jsonl"
+    placeholder_row = {
+        "callable": True,
+        "trial_id": "t0",
+        "attack_id": "a0",
+        "input_text": "[EMPTY]",
+        "output_text": "[EMPTY]",
+    }
+    literal_row = {
+        "callable": True,
+        "trial_id": "t1",
+        "attack_id": "a1",
+        "input_text": "Prompt literal",
+        "output_text": "Response literal",
+    }
+    rows_payload = [placeholder_row] * 9 + [literal_row]
+    rows_path.write_text("\n".join(json.dumps(r) for r in rows_payload) + "\n", encoding="utf-8")
+
+    section_html = mk_report.render_trial_io_section(run_dir, trial_limit=1000)
+
+    assert "WARNING" in section_html


### PR DESCRIPTION
## Summary
- ensure `run_real.persist_attempt` builds the literal prompt, coerces the raw response text, persists `input_text`/`output_text` per callable row, and writes optional DEBUG traces
- refactor report utilities and trial I/O rendering to prefer the new literal fields while preserving fallbacks, add placeholder diagnostics, and surface a warning when ≥80% of previews are empty
- add a trace CLI plus regression tests exercising per-attempt persistence, report rendering, placeholder warnings, and legacy compatibility

## Diagnostics
1. Prompt construction point – `build_final_prompt` now feeds the literal payload straight into `call_model` and stores that string verbatim in each row; DEBUG mode prints the first three prompts/responses and writes `trial_io_debug.txt`.
2. Model response capture – `extract_text` coercion ensures a string is produced, and `[EMPTY]` is persisted when the text is actually empty.
3. Row persistence – every callable attempt now writes `trial_id`, `attack_id`, `input_text`, `output_text`, `success`, `pre_gate`, `post_gate`, and `callable` to `rows.jsonl`, flushing and fsyncing per line; DEBUG tracing mirrors the same values.
4. Cardinality – the end-to-end test asserts an A×T fixture yields A×T callable rows and A×T rendered table rows with literal text.
5. Report build – the new resolver prefers `input_text`/`output_text`, falls back through legacy keys, and never blanks placeholders.
6. Template – the Trial I/O table renders `trial_id`, `attack_id`, `success`, `input`, and `output` columns with expand/collapse behavior and visible `[EMPTY]` sentinels.
7. ASR tally – regression tests ensure ✅/❌ counts in the table match the ASR summary for the fixture.

## Testing
- pytest tools/tests -q


------
https://chatgpt.com/codex/tasks/task_e_68d7ebb8ce748329bb5a2ee8efdec3a5