### PR TITLE
workflow: add single-attack smoke to print literal input/output in CI logs (no HTML)

### DIFF
--- a/.github/workflows/single-attack-smoke.yml
+++ b/.github/workflows/single-attack-smoke.yml
@@ -1,0 +1,63 @@
+name: Single Attack Smoke (Log I/O)
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: "Attack prompt to send (exact string)"
+        type: string
+        required: true
+      provider:
+        description: "Provider alias used by runner (e.g., groq, openai, local)"
+        type: choice
+        options: [groq, openai, local]
+        default: groq
+      model:
+        description: "Model identifier (e.g., llama-3.1-8b-instant)"
+        type: string
+        default: llama-3.1-8b-instant
+      temperature:
+        description: "Sampling temperature"
+        type: number
+        default: 0.0
+
+jobs:
+  single-attack:
+    runs-on: ubuntu-latest
+    env:
+      PROVIDER: ${{ inputs.provider }}
+      MODEL_ID: ${{ inputs.model }}
+      TEMPERATURE: ${{ inputs.temperature }}
+      ATTACK_PROMPT: ${{ inputs.prompt }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      PYTHONUTF8: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install repo (if needed)
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run single attack and print I/O
+        run: |
+          python tools/smoke_single_attack.py \
+            --provider "${PROVIDER}" \
+            --model "${MODEL_ID}" \
+            --temperature "${TEMPERATURE}" \
+            --prompt "${ATTACK_PROMPT}"
+
+      - name: Upload I/O log artifact (optional)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: single-attack-io
+          path: smoke_single_attack.log
+          if-no-files-found: ignore

--- a/tools/smoke_single_attack.py
+++ b/tools/smoke_single_attack.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Run a single attack prompt and print literal model I/O."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Mapping
+
+try:
+    from tools.run_real import build_final_prompt, extract_text as response_parser
+except Exception as exc:  # pragma: no cover - import error surfaced to caller
+    print(
+        "ERROR: Cannot import required utilities from tools.run_real:"
+        f" {type(exc).__name__}: {exc}",
+        file=sys.stderr,
+    )
+    raise
+
+
+def _http_post(url: str, headers: Mapping[str, str], payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    for key, value in headers.items():
+        req.add_header(key, value)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="ignore")
+        raise RuntimeError(f"HTTP {exc.code} {exc.reason}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Network error: {exc}") from exc
+    return json.loads(raw.decode("utf-8"))
+
+
+def _call_groq(prompt: str, model: str, temperature: float) -> Mapping[str, Any]:
+    key = os.environ.get("GROQ_API_KEY")
+    if not key:
+        raise RuntimeError("Missing GROQ_API_KEY")
+    payload = {
+        "model": model or "llama-3.1-8b-instant",
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": float(temperature),
+    }
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    return _http_post(
+        "https://api.groq.com/openai/v1/chat/completions",
+        headers,
+        payload,
+    )
+
+
+def _call_openai(prompt: str, model: str, temperature: float) -> Mapping[str, Any]:
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        raise RuntimeError("Missing OPENAI_API_KEY")
+    payload = {
+        "model": model or "gpt-4o-mini",
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": float(temperature),
+    }
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    return _http_post(
+        "https://api.openai.com/v1/chat/completions",
+        headers,
+        payload,
+    )
+
+
+def _call_local(prompt: str) -> Mapping[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": prompt,
+                }
+            }
+        ]
+    }
+
+
+def call_model(prompt: str, *, provider: str, model: str, temperature: float) -> Mapping[str, Any]:
+    provider_key = (provider or "").strip().lower()
+    if provider_key == "groq":
+        return _call_groq(prompt, model, temperature)
+    if provider_key == "openai":
+        return _call_openai(prompt, model, temperature)
+    if provider_key == "local":
+        return _call_local(prompt)
+    raise RuntimeError(f"Unsupported provider: {provider}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Single-attack smoke: print literal INPUT and OUTPUT",
+    )
+    parser.add_argument("--provider", required=True, help="Provider alias (groq|openai|local)")
+    parser.add_argument("--model", required=True, help="Model identifier")
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.0,
+        help="Sampling temperature",
+    )
+    parser.add_argument("--prompt", required=True, help="Attack prompt to send (exact string)")
+    args = parser.parse_args()
+
+    case: Mapping[str, Any] = {
+        "attack_id": "smoke-0",
+        "attack_prompt": args.prompt,
+        "input_case": {"prompt": args.prompt},
+        "prompt": args.prompt,
+    }
+
+    try:
+        final_prompt = build_final_prompt(case)
+    except Exception:
+        final_prompt = args.prompt
+
+    model_args = {
+        "provider": args.provider,
+        "model": args.model,
+        "temperature": args.temperature,
+    }
+
+    start = time.time()
+    response = call_model(final_prompt, **model_args)
+    latency_ms = int((time.time() - start) * 1000)
+    text = response_parser(response) or ""
+
+    log_path = os.path.abspath("smoke_single_attack.log")
+    with open(log_path, "w", encoding="utf-8") as handle:
+        handle.write("=== SINGLE ATTACK SMOKE ===\n")
+        handle.write(
+            f"provider: {args.provider}\nmodel: {args.model}\ntemperature: {args.temperature}\n",
+        )
+        handle.write(f"latency_ms: {latency_ms}\n")
+        handle.write("\n--- INPUT (literal prompt) ---\n")
+        handle.write(final_prompt + "\n")
+        handle.write("\n--- OUTPUT (raw model text) ---\n")
+        handle.write(text + "\n")
+
+    print("::group::SINGLE ATTACK — INPUT (literal)")
+    print(final_prompt)
+    print("::endgroup::")
+    print("::group::SINGLE ATTACK — OUTPUT (raw)")
+    print(text if text else "[EMPTY]")
+    print("::endgroup::")
+    print(f"[single-attack] provider={args.provider} model={args.model} latency_ms={latency_ms}")
+    print(f"[single-attack] log saved: {log_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a workflow_dispatch action to run a single prompt attack and echo literal model input/output to the log
- implement tools/smoke_single_attack.py to build the prompt, call the requested provider, and emit grouped log + artifact

## Testing
- python -m py_compile tools/smoke_single_attack.py

------
https://chatgpt.com/codex/tasks/task_e_68d7fb1c0afc8329a6231790f51eeda1