### PR TITLE
Improve smoke test provider handling

### DIFF
--- a/.github/workflows/single-attack-smoke.yml
+++ b/.github/workflows/single-attack-smoke.yml
@@ -8,9 +8,9 @@ on:
         type: string
         required: true
       provider:
-        description: "Provider alias used by runner (e.g., groq, openai, local)"
+        description: "Provider"
         type: choice
-        options: [groq, openai, local]
+        options: [groq, openai, mock]
         default: groq
       model:
         description: "Model identifier (e.g., llama-3.1-8b-instant)"
@@ -31,10 +31,27 @@ jobs:
       ATTACK_PROMPT: ${{ inputs.prompt }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # explicit bases (override in env if needed)
+      GROQ_API_BASE: https://api.groq.com/openai/v1
+      OPENAI_API_BASE: https://api.openai.com/v1
       PYTHONUTF8: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Choose provider (fallback to mock if key missing)
+        id: choose
+        run: |
+          provider="${PROVIDER}"
+          if [ "$provider" = "groq" ] && [ -z "${GROQ_API_KEY}" ]; then
+            echo "No GROQ_API_KEY; falling back to MOCK."
+            echo "provider=mock" >> $GITHUB_OUTPUT
+          elif [ "$provider" = "openai" ] && [ -z "${OPENAI_API_KEY}" ]; then
+            echo "No OPENAI_API_KEY; falling back to MOCK."
+            echo "provider=mock" >> $GITHUB_OUTPUT
+          else
+            echo "provider=$provider" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -47,12 +64,17 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Run single attack and print I/O
+        env:
+          PROVIDER: ${{ steps.choose.outputs.provider }}
         run: |
+          echo "Using provider: ${PROVIDER}"
           python tools/smoke_single_attack.py \
             --provider "${PROVIDER}" \
             --model "${MODEL_ID}" \
             --temperature "${TEMPERATURE}" \
-            --prompt "${ATTACK_PROMPT}"
+            --prompt "${ATTACK_PROMPT}" \
+            --groq-base "${GROQ_API_BASE}" \
+            --openai-base "${OPENAI_API_BASE}"
 
       - name: Upload I/O log artifact (optional)
         if: always()
@@ -60,4 +82,4 @@ jobs:
         with:
           name: single-attack-io
           path: smoke_single_attack.log
-          if-no-files-found: ignore
+          if-no-files-found: warn

--- a/tools/smoke_single_attack.py
+++ b/tools/smoke_single_attack.py
@@ -1,173 +1,160 @@
 #!/usr/bin/env python3
-"""Run a single attack prompt and print literal model I/O."""
+"""Single attack smoke test client.
+
+This script intentionally avoids external dependencies while providing
+robust HTTP handling and a deterministic mock fallback so that smoke
+runs always emit both INPUT and OUTPUT logs.
+"""
 
 from __future__ import annotations
 
 import argparse
 import json
 import os
-import sys
 import time
 import urllib.error
 import urllib.request
-from pathlib import Path
-from typing import Any, Mapping
 
-TOOLS_DIR = Path(__file__).resolve().parent
-ROOT_DIR = TOOLS_DIR.parent
-
-for path_dir in (TOOLS_DIR, ROOT_DIR):
-    str_path = str(path_dir)
-    if str_path not in sys.path:
-        sys.path.insert(0, str_path)
-
-try:
-    from run_real import build_final_prompt, extract_text as response_parser
-except Exception as exc:  # pragma: no cover - import error surfaced to caller
-    print(
-        "ERROR: Cannot import required utilities from run_real:",
-        f" {type(exc).__name__}: {exc}",
-        file=sys.stderr,
-    )
-    raise
+UA = "DoomArena-SMOKE/1.0 (+github-actions)"
 
 
-def _http_post(url: str, headers: Mapping[str, str], payload: Mapping[str, Any]) -> Mapping[str, Any]:
+def _http_post(url: str, headers: dict[str, str], payload: dict, timeout: int = 60) -> dict:
+    """Send a JSON POST request and return the parsed JSON response."""
+
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(url, data=data, method="POST")
     for key, value in headers.items():
         req.add_header(key, value)
+    req.add_header("User-Agent", UA)
+
     try:
-        with urllib.request.urlopen(req, timeout=60) as resp:
-            raw = resp.read()
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="ignore")
-        raise RuntimeError(f"HTTP {exc.code} {exc.reason}: {detail}") from exc
-    except urllib.error.URLError as exc:
-        raise RuntimeError(f"Network error: {exc}") from exc
-    return json.loads(raw.decode("utf-8"))
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            return json.loads(body)
+    except urllib.error.HTTPError as exc:  # pragma: no cover - exercised in CI
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code} {exc.reason} @ {url}\n{detail}") from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - exercised in CI
+        raise RuntimeError(f"Network error to {url}: {exc}") from exc
 
 
-def _call_groq(prompt: str, model: str, temperature: float) -> Mapping[str, Any]:
-    key = os.environ.get("GROQ_API_KEY")
-    if not key:
-        raise RuntimeError("Missing GROQ_API_KEY")
+def _call_groq(prompt: str, model: str, temperature: float, base: str) -> str:
+    api_key = os.getenv("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError("GROQ_API_KEY is not set")
+
+    url = f"{base.rstrip('/')}/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
     payload = {
-        "model": model or "llama-3.1-8b-instant",
+        "model": model,
         "messages": [{"role": "user", "content": prompt}],
         "temperature": float(temperature),
     }
-    headers = {
-        "Authorization": f"Bearer {key}",
-        "Content-Type": "application/json",
-    }
-    return _http_post(
-        "https://api.groq.com/openai/v1/chat/completions",
-        headers,
-        payload,
+    response = _http_post(url, headers, payload)
+    return (
+        response.get("choices", [{}])[0]
+        .get("message", {})
+        .get("content", "")
+        or ""
     )
 
 
-def _call_openai(prompt: str, model: str, temperature: float) -> Mapping[str, Any]:
-    key = os.environ.get("OPENAI_API_KEY")
-    if not key:
-        raise RuntimeError("Missing OPENAI_API_KEY")
+def _call_openai(prompt: str, model: str, temperature: float, base: str) -> str:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is not set")
+
+    url = f"{base.rstrip('/')}/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
     payload = {
-        "model": model or "gpt-4o-mini",
+        "model": model,
         "messages": [{"role": "user", "content": prompt}],
         "temperature": float(temperature),
     }
-    headers = {
-        "Authorization": f"Bearer {key}",
-        "Content-Type": "application/json",
-    }
-    return _http_post(
-        "https://api.openai.com/v1/chat/completions",
-        headers,
-        payload,
+    response = _http_post(url, headers, payload)
+    return (
+        response.get("choices", [{}])[0]
+        .get("message", {})
+        .get("content", "")
+        or ""
     )
 
 
-def _call_local(prompt: str) -> Mapping[str, Any]:
-    return {
-        "choices": [
-            {
-                "message": {
-                    "role": "assistant",
-                    "content": prompt,
-                }
-            }
-        ]
-    }
-
-
-def call_model(prompt: str, *, provider: str, model: str, temperature: float) -> Mapping[str, Any]:
-    provider_key = (provider or "").strip().lower()
-    if provider_key == "groq":
-        return _call_groq(prompt, model, temperature)
-    if provider_key == "openai":
-        return _call_openai(prompt, model, temperature)
-    if provider_key == "local":
-        return _call_local(prompt)
-    raise RuntimeError(f"Unsupported provider: {provider}")
+def _call_mock(prompt: str) -> str:
+    return (
+        "MOCKED RESPONSE\n"
+        "This is a deterministic placeholder used when provider connectivity fails or API keys are missing.\n"
+        "Echo of attack prompt:\n"
+        f"{prompt[:500]}"
+    )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Single-attack smoke: print literal INPUT and OUTPUT",
     )
-    parser.add_argument("--provider", required=True, help="Provider alias (groq|openai|local)")
-    parser.add_argument("--model", required=True, help="Model identifier")
+    parser.add_argument("--provider", required=True, choices=["groq", "openai", "mock"])
+    parser.add_argument("--model", default="llama-3.1-8b-instant")
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--prompt", required=True)
     parser.add_argument(
-        "--temperature",
-        type=float,
-        default=0.0,
-        help="Sampling temperature",
+        "--groq-base",
+        default=os.getenv("GROQ_API_BASE", "https://api.groq.com/openai/v1"),
     )
-    parser.add_argument("--prompt", required=True, help="Attack prompt to send (exact string)")
+    parser.add_argument(
+        "--openai-base",
+        default=os.getenv("OPENAI_API_BASE", "https://api.openai.com/v1"),
+    )
     args = parser.parse_args()
 
-    case: Mapping[str, Any] = {
-        "attack_id": "smoke-0",
-        "attack_prompt": args.prompt,
-        "input_case": {"prompt": args.prompt},
-        "prompt": args.prompt,
-    }
-
-    try:
-        final_prompt = build_final_prompt(case)
-    except Exception:
-        final_prompt = args.prompt
-
-    model_args = {
-        "provider": args.provider,
-        "model": args.model,
-        "temperature": args.temperature,
-    }
+    final_prompt = args.prompt
 
     start = time.time()
-    response = call_model(final_prompt, **model_args)
+    try:
+        if args.provider == "groq":
+            output = _call_groq(final_prompt, args.model, args.temperature, args.groq_base)
+        elif args.provider == "openai":
+            output = _call_openai(final_prompt, args.model, args.temperature, args.openai_base)
+        else:
+            output = _call_mock(final_prompt)
+        err_msg = None
+    except Exception as exc:  # pragma: no cover - intended for smoke diagnostics
+        err_msg = str(exc)
+        output = _call_mock(final_prompt)
     latency_ms = int((time.time() - start) * 1000)
-    text = response_parser(response) or ""
 
     log_path = os.path.abspath("smoke_single_attack.log")
     with open(log_path, "w", encoding="utf-8") as handle:
         handle.write("=== SINGLE ATTACK SMOKE ===\n")
         handle.write(
-            f"provider: {args.provider}\nmodel: {args.model}\ntemperature: {args.temperature}\n",
+            f"provider: {args.provider}\nmodel: {args.model}\ntemperature: {args.temperature}\n"
         )
         handle.write(f"latency_ms: {latency_ms}\n")
+        if err_msg:
+            handle.write("\n--- ERROR (real call failed; showing MOCK output) ---\n")
+            handle.write(err_msg + "\n")
         handle.write("\n--- INPUT (literal prompt) ---\n")
         handle.write(final_prompt + "\n")
-        handle.write("\n--- OUTPUT (raw model text) ---\n")
-        handle.write(text + "\n")
+        handle.write("\n--- OUTPUT (raw text) ---\n")
+        handle.write(output + "\n")
 
     print("::group::SINGLE ATTACK — INPUT (literal)")
     print(final_prompt)
     print("::endgroup::")
     print("::group::SINGLE ATTACK — OUTPUT (raw)")
-    print(text if text else "[EMPTY]")
+    print(output if output else "[EMPTY]")
     print("::endgroup::")
+    if err_msg:
+        print(
+            "::warning:: Real provider call failed; printed MOCK output instead. Error was:\n"
+            + err_msg
+        )
     print(f"[single-attack] provider={args.provider} model={args.model} latency_ms={latency_ms}")
     print(f"[single-attack] log saved: {log_path}")
 


### PR DESCRIPTION
## Summary
- allow selecting groq, openai, or mock providers in the smoke workflow and fall back to mock when API keys are missing
- pass explicit API base URLs and surface the selected provider in the workflow logs
- replace the smoke client with a hardened HTTP implementation that prints detailed errors and always emits deterministic mock output on failure

## Testing
- python tools/smoke_single_attack.py --provider mock --model test --prompt 'hello'

------
https://chatgpt.com/codex/tasks/task_e_68d8027040108329b39f15be2f3f79af