### PR TITLE
ci: fix demo-straight-mvp key plumbing + preflight (GROQ_API_KEY) with optional mock fallback

### DIFF
--- a/.github/workflows/demo-straight-mvp.yml
+++ b/.github/workflows/demo-straight-mvp.yml
@@ -4,34 +4,42 @@ on:
   workflow_dispatch:
     inputs:
       provider:
-        description: "Provider to call"
-        required: true
-        default: "mock"
         type: choice
-        options:
-          - groq
-          - openai
-          - mock
+        options: [groq, openai, mock]
+        default: groq
       model:
-        description: "Model identifier"
-        required: true
-        default: "llama-3.1-8b-instant"
+        type: string
+        default: llama-3.1-8b-instant
       trials:
-        description: "Trials per case"
-        required: false
-        default: "10"
+        type: number
+        default: 10
       temperature:
-        description: "Sampling temperature"
-        required: false
-        default: "0.0"
+        type: number
+        default: 0.0
       seed:
-        description: "Deterministic translation seed"
-        required: false
-        default: "42"
+        type: number
+        default: 42
+      allow_mock_fallback:
+        description: "If real key is missing, auto-switch to mock"
+        type: boolean
+        default: false
 
 jobs:
-  run-demo:
+  mvp:
     runs-on: ubuntu-latest
+    env:
+      PROVIDER: ${{ inputs.provider }}
+      MODEL_ID: ${{ inputs.model }}
+      TRIALS: ${{ inputs.trials }}
+      TEMPERATURE: ${{ inputs.temperature }}
+      SEED: ${{ inputs.seed }}
+      ALLOW_MOCK: ${{ inputs.allow_mock_fallback }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GROQ_API_BASE: https://api.groq.com/openai/v1
+      OPENAI_API_BASE: https://api.openai.com/v1
+      PYTHONUTF8: "1"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -39,44 +47,88 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
+      - name: Preflight: provider keys present?
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          provider="${PROVIDER}"
+          allow="${ALLOW_MOCK}"
+          if [[ "$provider" == "groq" ]]; then
+            if [[ -z "${GROQ_API_KEY}" ]]; then
+              if [[ "$allow" == "true" ]]; then
+                echo "::warning:: GROQ_API_KEY missing → switching provider=mock"
+                echo "provider=mock" >> $GITHUB_OUTPUT
+              else
+                echo "::error:: GROQ_API_KEY is not set. Add it under Settings → Secrets and rerun (or set allow_mock_fallback=true)."
+                exit 1
+              fi
+            else
+              echo "::notice:: GROQ_API_KEY detected"
+              echo "provider=groq" >> $GITHUB_OUTPUT
+            fi
+          elif [[ "$provider" == "openai" ]]; then
+            if [[ -z "${OPENAI_API_KEY}" ]]; then
+              if [[ "$allow" == "true" ]]; then
+                echo "::warning:: OPENAI_API_KEY missing → switching provider=mock"
+                echo "provider=mock" >> $GITHUB_OUTPUT
+              else
+                echo "::error:: OPENAI_API_KEY is not set. Add it under Settings → Secrets and rerun (or set allow_mock_fallback=true)."
+                exit 1
+              fi
+            else
+              echo "::notice:: OPENAI_API_KEY detected"
+              echo "provider=openai" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "provider=mock" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install repo (if any reqs)
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-      - name: Set RUN_ID
+      - name: Translate NL threats → cases
         run: |
-          RUN_ID="$(date -u +%Y%m%d-%H%M%S)"
-          echo "RUN_ID=$RUN_ID" >> "$GITHUB_ENV"
-          echo "RUN_ID=$RUN_ID"
+          python tools/mvp_translate.py \
+            --spec specs/mvp_threats.yaml \
+            --seed "${SEED}" \
+            --out cases_mvp.jsonl
 
-      - name: Translate threats
-        run: |
-          python tools/mvp_translate.py --spec specs/mvp_threats.yaml --seed "${{ inputs.seed }}" --out cases_mvp.jsonl
-
-      - name: Execute trials
+      - name: Run attempts (straight-through)
         env:
-          RUN_ID: ${{ env.RUN_ID }}
+          EFFECTIVE_PROVIDER: ${{ steps.preflight.outputs.provider }}
         run: |
-          python tools/mvp_run.py --cases cases_mvp.jsonl --provider "${{ inputs.provider }}" --model "${{ inputs.model }}" --temperature "${{ inputs.temperature }}" --trials "${{ inputs.trials }}" --run-dir "results/${RUN_ID}"
+          RUN_ID="$(date +%Y%m%d-%H%M%S)"
+          echo "RUN_ID=$RUN_ID" >> $GITHUB_ENV
+          python tools/mvp_run.py \
+            --cases cases_mvp.jsonl \
+            --provider "${EFFECTIVE_PROVIDER}" \
+            --model "${MODEL_ID}" \
+            --temperature "${TEMPERATURE}" \
+            --trials "${TRIALS}" \
+            --run-dir "results/${RUN_ID}" \
+            --groq-base "${GROQ_API_BASE}" \
+            --openai-base "${OPENAI_API_BASE}" \
+            --allow-mock-fallback "${ALLOW_MOCK}"
 
-      - name: Verify outputs
-        env:
-          RUN_ID: ${{ env.RUN_ID }}
+      - name: Verify results
         run: |
-          python tools/mvp_verify.py --rows "results/${RUN_ID}/rows.jsonl" --spec specs/mvp_threats.yaml --out "results/${RUN_ID}/summary.csv"
+          python tools/mvp_verify.py \
+            --rows "results/${RUN_ID}/rows.jsonl" \
+            --spec specs/mvp_threats.yaml \
+            --out "results/${RUN_ID}/summary.csv"
 
       - name: Build minimal report
-        env:
-          RUN_ID: ${{ env.RUN_ID }}
         run: |
-          python tools/mvp_report_min.py --rows "results/${RUN_ID}/rows.jsonl" --summary "results/${RUN_ID}/summary.csv" --out "results/${RUN_ID}/index.html"
+          python tools/mvp_report_min.py \
+            --rows "results/${RUN_ID}/rows.jsonl" \
+            --summary "results/${RUN_ID}/summary.csv" \
+            --out "results/${RUN_ID}/index.html"
 
       - name: Upload artifacts
-        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: demo-mvp-${{ env.RUN_ID }}
-          path: results/${{ env.RUN_ID }}/
-          if-no-files-found: error
-          retention-days: 7
+          name: results-${{ env.RUN_ID }}
+          path: results/${{ env.RUN_ID }}

--- a/tools/mvp_run.py
+++ b/tools/mvp_run.py
@@ -20,20 +20,29 @@ import smoke_single_attack  # type: ignore
 ProviderCaller = Callable[[str, str, float], str]
 
 
-def _build_caller(provider: str) -> ProviderCaller:
+def _parse_bool(value: str | bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    text = value.strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    raise argparse.ArgumentTypeError(f"Expected a boolean value, got: {value!r}")
+
+
+def _build_caller(provider: str, *, groq_base: str, openai_base: str) -> ProviderCaller:
     provider = provider.lower()
     if provider == "groq":
-        base = os.getenv("GROQ_API_BASE", "https://api.groq.com/openai/v1")
 
         def _call(prompt: str, model: str, temperature: float) -> str:
-            return smoke_single_attack._call_groq(prompt, model, temperature, base)
+            return smoke_single_attack._call_groq(prompt, model, temperature, groq_base)
 
         return _call
     if provider == "openai":
-        base = os.getenv("OPENAI_API_BASE", "https://api.openai.com/v1")
 
         def _call(prompt: str, model: str, temperature: float) -> str:
-            return smoke_single_attack._call_openai(prompt, model, temperature, base)
+            return smoke_single_attack._call_openai(prompt, model, temperature, openai_base)
 
         return _call
     if provider == "mock":
@@ -65,9 +74,55 @@ def main() -> None:
     parser.add_argument("--temperature", required=True, type=float)
     parser.add_argument("--trials", required=True, type=int)
     parser.add_argument("--run-dir", required=True, type=pathlib.Path)
+    parser.add_argument(
+        "--groq-base",
+        default=os.getenv("GROQ_API_BASE", "https://api.groq.com/openai/v1"),
+    )
+    parser.add_argument(
+        "--openai-base",
+        default=os.getenv("OPENAI_API_BASE", "https://api.openai.com/v1"),
+    )
+    parser.add_argument(
+        "--allow-mock-fallback",
+        default=False,
+        type=_parse_bool,
+    )
     args = parser.parse_args()
 
-    caller = _build_caller(args.provider)
+    requested_provider = args.provider
+    groq_key = os.getenv("GROQ_API_KEY", "") if requested_provider == "groq" else "present"
+    openai_key = (
+        os.getenv("OPENAI_API_KEY", "") if requested_provider == "openai" else "present"
+    )
+
+    missing_key_code: str | None = None
+    missing_key_message: str | None = None
+    effective_provider = requested_provider
+
+    if requested_provider == "groq" and not groq_key:
+        missing_key_code = "MISSING_GROQ_API_KEY"
+        missing_key_message = "[ERROR] GROQ_API_KEY missing"
+        if args.allow_mock_fallback:
+            effective_provider = "mock"
+        else:
+            effective_provider = "none"
+    elif requested_provider == "openai" and not openai_key:
+        missing_key_code = "MISSING_OPENAI_API_KEY"
+        missing_key_message = "[ERROR] OPENAI_API_KEY missing"
+        if args.allow_mock_fallback:
+            effective_provider = "mock"
+        else:
+            effective_provider = "none"
+
+    caller: ProviderCaller | None
+    if effective_provider == "none":
+        caller = None
+    else:
+        caller = _build_caller(
+            effective_provider,
+            groq_base=args.groq_base,
+            openai_base=args.openai_base,
+        )
     cases = _load_cases(args.cases)
 
     run_dir = args.run_dir
@@ -75,7 +130,8 @@ def main() -> None:
     rows_path = run_dir / "rows.jsonl"
 
     run_meta = {
-        "provider": args.provider,
+        "provider": requested_provider,
+        "effective_provider": effective_provider,
         "model": args.model,
         "temperature": args.temperature,
         "trials": args.trials,
@@ -94,22 +150,33 @@ def main() -> None:
                 continue
             for trial_index in range(args.trials):
                 trial_id = f"{attack_id}-{trial_index}"
-                try:
-                    output_text = caller(prompt, args.model, args.temperature)
-                    error_text = ""
-                except Exception as exc:  # pragma: no cover - diagnostics path
-                    output_text = "[ERROR]"
-                    error_text = str(exc)
+                row_errors: list[str] = []
+                if missing_key_code and args.allow_mock_fallback:
+                    row_errors.append(missing_key_code)
+                if caller is None:
+                    output_text = missing_key_message or "[ERROR] Provider unavailable"
+                    if missing_key_code and not args.allow_mock_fallback:
+                        row_errors.append(missing_key_code)
+                else:
+                    try:
+                        output_text = caller(prompt, args.model, args.temperature)
+                    except Exception as exc:  # pragma: no cover - diagnostics path
+                        error_text = str(exc)
+                        truncated = error_text[:500]
+                        if len(error_text) > 500:
+                            truncated = truncated.rstrip() + "…"
+                        output_text = f"[ERROR] {truncated}" if truncated else "[ERROR]"
+                        row_errors.append(error_text)
                 row: dict[str, Any] = {
                     "trial_id": trial_id,
                     "attack_id": attack_id,
                     "persona": persona,
                     "input_text": prompt,
                     "output_text": output_text if isinstance(output_text, str) else str(output_text),
-                    "callable": True,
+                    "callable": caller is not None,
                 }
-                if error_text:
-                    row["error"] = error_text
+                if row_errors:
+                    row["error"] = " | ".join(row_errors)
                 handle.write(json.dumps(row, ensure_ascii=False) + "\n")
 
 


### PR DESCRIPTION
## Summary
- add an allow_mock_fallback input and preflight guardrails for GROQ/OpenAI keys in the demo-straight-mvp workflow
- pass provider secrets and base URLs through the workflow env and thread new CLI flags to mvp_run.py
- improve mvp_run.py error handling for missing API keys and provider exceptions while preserving informative outputs

## Testing
- python -m compileall tools/mvp_run.py

------
https://chatgpt.com/codex/tasks/task_e_68d80c38984083298ceab92744a9bb6d