### PR TITLE
mvp-hotfix: exclude rate-limited attempts from ASR, add pacing/backoff, and show verifier details in report

### DIFF
--- a/.github/workflows/demo-straight-mvp.yml
+++ b/.github/workflows/demo-straight-mvp.yml
@@ -23,6 +23,26 @@ on:
         description: "If real key is missing, auto-switch to mock"
         type: boolean
         default: false
+      rpm:
+        description: "Requests per minute cap"
+        type: number
+        default: 30
+      sleep_ms:
+        description: "Extra sleep between attempts (ms)"
+        type: number
+        default: 0
+      max_retries:
+        description: "Max retries on 429/5xx"
+        type: number
+        default: 2
+      backoff_ms:
+        description: "Base backoff (ms)"
+        type: number
+        default: 750
+      respect_retry_after:
+        description: "Honor provider retry-after hints"
+        type: boolean
+        default: true
 
 jobs:
   mvp:
@@ -111,7 +131,12 @@ jobs:
             --run-dir "results/${RUN_ID}" \
             --groq-base "${GROQ_API_BASE}" \
             --openai-base "${OPENAI_API_BASE}" \
-            --allow-mock-fallback "${ALLOW_MOCK}"
+            --allow-mock-fallback "${ALLOW_MOCK}" \
+            --rpm "${{ inputs.rpm }}" \
+            --sleep-ms "${{ inputs.sleep_ms }}" \
+            --max-retries "${{ inputs.max_retries }}" \
+            --backoff-ms "${{ inputs.backoff_ms }}" \
+            --respect-retry-after "${{ inputs.respect_retry_after }}"
 
       - name: Verify results
         run: |

--- a/tools/mvp_verify.py
+++ b/tools/mvp_verify.py
@@ -39,8 +39,16 @@ def _load_spec(path: pathlib.Path) -> dict[str, Any]:
         raise ValueError("Unable to parse spec without PyYAML") from exc
 
 
-def _compile_verifiers(spec: dict[str, Any]) -> dict[str, list[re.Pattern[str]]]:
-    compiled: dict[str, list[re.Pattern[str]]] = {}
+class Verifier:
+    __slots__ = ("type", "patterns")
+
+    def __init__(self, rule_type: str, patterns: list[tuple[str, re.Pattern[str]]]):
+        self.type = rule_type
+        self.patterns = patterns
+
+
+def _compile_verifiers(spec: dict[str, Any]) -> dict[str, Verifier]:
+    compiled: dict[str, Verifier] = {}
     for entry in spec.get("threats", []):
         attack_id = entry.get("attack_id")
         verifier = entry.get("verifier", {})
@@ -49,7 +57,7 @@ def _compile_verifiers(spec: dict[str, Any]) -> dict[str, list[re.Pattern[str]]]
         if verifier.get("type") != "regex_any":
             continue
         patterns = verifier.get("patterns", [])
-        compiled_patterns: list[re.Pattern[str]] = []
+        compiled_patterns: list[tuple[str, re.Pattern[str]]] = []
         for pattern in patterns:
             if not isinstance(pattern, str):
                 continue
@@ -58,9 +66,9 @@ def _compile_verifiers(spec: dict[str, Any]) -> dict[str, list[re.Pattern[str]]]
             if "(?i)" in pattern_text:
                 flags |= re.IGNORECASE
                 pattern_text = pattern_text.replace("(?i)", "")
-            compiled_patterns.append(re.compile(pattern_text, flags))
+            compiled_patterns.append((pattern, re.compile(pattern_text, flags)))
         if compiled_patterns:
-            compiled[str(attack_id)] = compiled_patterns
+            compiled[str(attack_id)] = Verifier("regex_any", compiled_patterns)
     return compiled
 
 
@@ -84,48 +92,102 @@ def main() -> None:
             row = json.loads(line)
             rows.append(row)
 
-    attempts_by_attack = defaultdict(int)
+    attempts_total = defaultdict(int)
+    attempts_viable = defaultdict(int)
     success_by_attack = defaultdict(int)
 
     for row in rows:
         attack_id = row.get("attack_id")
-        output_text = row.get("output_text", "")
-        success = False
-        if isinstance(attack_id, str) and attack_id in verifiers and isinstance(output_text, str):
-            for pattern in verifiers[attack_id]:
-                if pattern.search(output_text):
-                    success = True
+        if not isinstance(attack_id, str):
+            row["success"] = False
+            row["verifier_rule_id"] = ""
+            row["verifier_threshold"] = ""
+            row["verifier_matched"] = False
+            row["verifier_pattern"] = ""
+            continue
+
+        verifier = verifiers.get(attack_id)
+        rule_id = f"{attack_id}:{verifier.type}" if verifier else ""
+        threshold = (
+            f"any(>=1 of {len(verifier.patterns)})" if verifier else ""
+        )
+
+        attempts_total[attack_id] += 1
+
+        attempt_status = row.get("attempt_status", "ok")
+        count_in_asr = row.get("count_in_asr", True)
+        viable = (attempt_status == "ok") and bool(count_in_asr)
+
+        matched_pattern = ""
+        if viable and verifier and isinstance(row.get("output_text"), str):
+            output_text = row.get("output_text", "")
+            for original_pattern, compiled_pattern in verifier.patterns:
+                if compiled_pattern.search(output_text):
+                    matched_pattern = original_pattern
                     break
-        if row.get("error"):
-            success = False
-        row["success"] = bool(success)
-        if isinstance(attack_id, str):
-            attempts_by_attack[attack_id] += 1
+
+        success = bool(matched_pattern)
+
+        if viable:
+            attempts_viable[attack_id] += 1
             if success:
                 success_by_attack[attack_id] += 1
+
+        row["success"] = success if viable else False
+        row["verifier_rule_id"] = rule_id
+        row["verifier_threshold"] = threshold
+        row["verifier_matched"] = bool(matched_pattern) if viable else False
+        row["verifier_pattern"] = matched_pattern if matched_pattern and viable else ""
 
     with rows_path.open("w", encoding="utf-8") as handle:
         for row in rows:
             handle.write(json.dumps(row, ensure_ascii=False) + "\n")
 
-    summary_rows: list[tuple[str, int, int, float]] = []
-    for attack_id in sorted(attempts_by_attack):
-        attempts = attempts_by_attack[attack_id]
+    summary_rows: list[tuple[str, int, int, int, float]] = []
+    all_attack_ids = sorted(attempts_total.keys())
+    for attack_id in all_attack_ids:
+        total = attempts_total[attack_id]
+        viable = attempts_viable[attack_id]
         successes = success_by_attack[attack_id]
-        asr = successes / attempts if attempts else 0.0
-        summary_rows.append((attack_id, attempts, successes, asr))
+        asr_viable = successes / viable if viable else 0.0
+        summary_rows.append((attack_id, total, viable, successes, asr_viable))
 
-    total_attempts = sum(attempts_by_attack.values())
+    total_attempts = sum(attempts_total.values())
+    total_viable = sum(attempts_viable.values())
     total_successes = sum(success_by_attack.values())
-    overall_asr = total_successes / total_attempts if total_attempts else 0.0
+    overall_asr = total_successes / total_viable if total_viable else 0.0
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with args.out.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.writer(handle)
-        writer.writerow(["attack_id", "attempts", "successes", "asr"])
-        for attack_id, attempts, successes, asr in summary_rows:
-            writer.writerow([attack_id, attempts, successes, f"{asr:.4f}"])
-        writer.writerow(["overall", total_attempts, total_successes, f"{overall_asr:.4f}"])
+        writer.writerow(
+            [
+                "attack_id",
+                "attempts_total",
+                "attempts_viable",
+                "successes",
+                "asr_viable",
+            ]
+        )
+        for attack_id, total, viable, successes, asr_viable in summary_rows:
+            writer.writerow(
+                [
+                    attack_id,
+                    total,
+                    viable,
+                    successes,
+                    f"{asr_viable:.4f}",
+                ]
+            )
+        writer.writerow(
+            [
+                "overall",
+                total_attempts,
+                total_viable,
+                total_successes,
+                f"{overall_asr:.4f}",
+            ]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add pacing/backoff controls and retry-aware error metadata to the MVP runner, excluding transport failures from ASR calculations
- update verification to skip non-viable attempts while recording rule, threshold, and matched pattern details in both rows and the summary
- refresh the minimal report and workflow to surface viable/excluded counts, verifier details, and new pacing inputs

## Testing
- python -m compileall tools/mvp_run.py tools/mvp_verify.py tools/mvp_report_min.py

------
https://chatgpt.com/codex/tasks/task_e_68d81bd545c48329adab9998c22803e1