### PR TITLE
Fix indentation of tuning_json parsing step

### DIFF
--- a/.github/workflows/demo-straight-mvp.yml
+++ b/.github/workflows/demo-straight-mvp.yml
@@ -59,34 +59,34 @@ jobs:
         with:
           python-version: "3.11"
 
-- name: "Parse tuning_json → env"
-  shell: bash
-  run: |
-    python - <<'PY'
-    import os, json
-    raw = os.environ.get("TUNING_JSON") or "{}"
-    try:
-        data = json.loads(raw)
-    except Exception:
-        data = {}
-    def put(name, value):
-        # Booleans must be "true"/"false" strings for subsequent CLI flags
-        if isinstance(value, bool):
-            value = "true" if value else "false"
-        with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as f:
-            f.write(f"{name}={value}\n")
-    defaults = {
-        "RPM": 30,
-        "SLEEP_MS": 0,
-        "MAX_RETRIES": 2,
-        "BACKOFF_MS": 750,
-        "RESPECT_RETRY_AFTER": True,
-        "MUTATE_TEMPERATURE": 0.7,
-        "COOLDOWN_AFTER_MUTATE_MS": 2000,
-    }
-    for k, v in defaults.items():
-        put(k, data.get(k.lower(), v))
-    PY
+      - name: "Parse tuning_json → env"
+        shell: bash
+        run: |
+          python - <<'PY'
+            import os, json
+            raw = os.environ.get("TUNING_JSON") or "{}"
+            try:
+                data = json.loads(raw)
+            except Exception:
+                data = {}
+            def put(name, value):
+                # Booleans must be "true"/"false" strings for subsequent CLI flags
+                if isinstance(value, bool):
+                    value = "true" if value else "false"
+                with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as f:
+                    f.write(f"{name}={value}\n")
+            defaults = {
+                "RPM": 30,
+                "SLEEP_MS": 0,
+                "MAX_RETRIES": 2,
+                "BACKOFF_MS": 750,
+                "RESPECT_RETRY_AFTER": True,
+                "MUTATE_TEMPERATURE": 0.7,
+                "COOLDOWN_AFTER_MUTATE_MS": 2000,
+            }
+            for k, v in defaults.items():
+                put(k, data.get(k.lower(), v))
+            PY
 
       - name: "Preflight: provider keys present?"
         id: preflight


### PR DESCRIPTION
## Summary
- re-indent the "Parse tuning_json → env" step so it remains under `jobs.mvp.steps`
- ensure the embedded Python block is indented relative to the restored step structure

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d828286c888329b739c83338cb4f82